### PR TITLE
fix: make popular questions backwards compatible

### DIFF
--- a/packages/components/chat/WelcomeChatMessage.tsx
+++ b/packages/components/chat/WelcomeChatMessage.tsx
@@ -1,11 +1,11 @@
-import { useTranslations } from 'next-intl';
-import { ReactMarkdown } from '@magi/components/ReactMarkdown';
-import { ChatBubble } from '@magi/components/chat/ChatCard';
-import { MagiEvent } from '@/lib/analytics/events';
-import { useAnalytics } from '@/lib/use-analytics';
-import { useCallback, useMemo, useContext } from 'react';
-import { useSettings } from '@/app/providers/SettingsProvider';
-import { ChatContext } from './Chat';
+import { useTranslations } from "next-intl";
+import { ReactMarkdown } from "@magi/components/ReactMarkdown";
+import { ChatBubble } from "@magi/components/chat/ChatCard";
+import { MagiEvent } from "@/lib/analytics/events";
+import { useAnalytics } from "@/lib/use-analytics";
+import { useCallback, useMemo, useContext } from "react";
+import { useSettings } from "@/app/providers/SettingsProvider";
+import { ChatContext } from "./Chat";
 
 interface WelcomeMessageProps {
   agentFriendlyId: string;
@@ -16,43 +16,46 @@ export function WelcomeMessage({
   agentFriendlyId,
   conversationId,
 }: WelcomeMessageProps) {
-  const t = useTranslations('chat.ChatPage');
+  const t = useTranslations("chat.ChatPage");
   const analytics = useAnalytics();
   const { ask } = useContext(ChatContext);
 
   const { popularQuestions: popularQuestionsJSON } = useSettings();
   const popularQuestions: string[] = useMemo(() => {
     try {
-        return JSON.parse(popularQuestionsJSON || '[]');
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
-        return [];
+      if (typeof popularQuestionsJSON === "string") {
+        return JSON.parse(popularQuestionsJSON || "[]");
       }
-    }, [popularQuestionsJSON]);
+      return popularQuestionsJSON || [];
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      return [];
+    }
+  }, [popularQuestionsJSON]);
 
   const handleQuestionClick = useCallback(
     (question: string) => {
       analytics.logEvent(MagiEvent.popularQuestionClick, {
         agentId: agentFriendlyId,
-        conversationId: conversationId || '',
+        conversationId: conversationId || "",
         question,
       });
       ask(question);
     },
-    [analytics, agentFriendlyId, conversationId, ask]
+    [analytics, agentFriendlyId, conversationId, ask],
   );
 
   return (
-    <ChatBubble direction='full' key='popular_questions'>
-      <div className='flex flex-col'>
-        <div className='mb-2 whitespace-pre-wrap'>
+    <ChatBubble direction="full" key="popular_questions">
+      <div className="flex flex-col">
+        <div className="mb-2 whitespace-pre-wrap">
           <ReactMarkdown linkTargetInNewTab>
-            {t('default_welcome_message')}
+            {t("default_welcome_message")}
           </ReactMarkdown>
         </div>
         {popularQuestions.slice(0, 3).map((question, index) => (
           <div
-            className='my-1 cursor-pointer underline'
+            className="my-1 cursor-pointer underline"
             key={index}
             onClick={() => handleQuestionClick(question)}
           >

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -4,7 +4,7 @@ declare global {
     brandColor: string;
     brandFontColor?: string;
     amplitudeApiKey: string;
-    popularQuestions: string;
+    popularQuestions: string[] | string;
     jwtPublicKey: string;
     encryptionSecret: string;
     handoffConfiguration?: string;
@@ -13,7 +13,7 @@ declare global {
   }
 
   type HandoffConfiguration = {
-    type: 'zendesk' | 'salesforce';
+    type: "zendesk" | "salesforce";
     subdomain: string;
     apiKey: string;
     apiSecret: string;
@@ -21,7 +21,7 @@ declare global {
   };
 
   interface ClientSafeAppSettings extends Partial<AppSettings> {
-    handoffConfiguration?: { type: HandoffConfiguration['type'] } | undefined;
+    handoffConfiguration?: { type: HandoffConfiguration["type"] } | undefined;
   }
 
   interface ParsedAppSettings extends AppSettings {


### PR DESCRIPTION
Updating `popularQuestions` appSettings property from `string` ➡️ `string[]`. This PR makes the property backwards compatible until we migrate all users.