### PR TITLE
fix: Remove 'action' key from chart messages

### DIFF
--- a/packages/components/chat/use-chat.tsx
+++ b/packages/components/chat/use-chat.tsx
@@ -289,7 +289,6 @@ export function useChat({ signedUserData }: UseChatOptions): UseChatReturn {
             m.conversationMessageId?.referenceId === referenceId
               ? {
                   ...m,
-                  action: parsedData,
                   responses: [
                     ...(m.responses || []),
                     {


### PR DESCRIPTION
Chart messages erroneously included an `action` property that caused a blank action form to be displayed.

![image](https://github.com/user-attachments/assets/732e6e5a-4608-4ee2-a0f0-ed3aa5d9148e)
