### PR TITLE
fix: await redis init before pub/sub

### DIFF
--- a/app/api/server/lib/redis.ts
+++ b/app/api/server/lib/redis.ts
@@ -1,18 +1,26 @@
-import { createClient } from 'redis';
+import { createClient } from "redis";
 
 // Create a Redis client factory
-const createRedisClient = () => {
+const createRedisClient = async () => {
   const client = createClient({
     url: process.env.STORAGE_REDIS_URL,
   });
 
-  client.on('error', (err) => console.error('Redis Client Error', err));
-  client.on('ready', () => console.log('Redis Client Ready'));
+  client.on("error", (err) => console.error("Redis Client Error", err));
+  client.on("ready", () => console.log("Redis Client Ready"));
+
+  await client.connect();
 
   return client;
 };
 
-// Create instance
-const redisClient = createRedisClient();
+const globalForRedis = global as unknown as {
+  redis: ReturnType<typeof createClient> | undefined;
+};
 
-export default redisClient;
+export const getRedisClient = async () => {
+  if (!globalForRedis.redis) {
+    globalForRedis.redis = await createRedisClient();
+  }
+  return globalForRedis.redis;
+};

--- a/app/api/zendesk/messages/route.ts
+++ b/app/api/zendesk/messages/route.ts
@@ -1,71 +1,78 @@
-import { type NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from "next/server";
 import {
   getSunshineConversationsClient,
   postMessagesToZendeskConversation,
-} from '@/app/api/zendesk/utils';
-import { withSettingsAndAuthentication } from '@/app/api/server/utils';
-import redisClient from '@/app/api/server/lib/redis';
+} from "@/app/api/zendesk/utils";
+import { withSettingsAndAuthentication } from "@/app/api/server/utils";
+import { getRedisClient } from "@/app/api/server/lib/redis";
 
 export async function POST(request: NextRequest) {
-  return withSettingsAndAuthentication(request, async (req, settings, _orgId, _agentId, userId, conversationId) => {
-    const { message } = await req.json();
+  return withSettingsAndAuthentication(
+    request,
+    async (req, settings, _orgId, _agentId, userId, conversationId) => {
+      const { message } = await req.json();
 
-    if (!settings.handoffConfiguration) {
-      throw new Error('Handoff configuration not found');
-    }
+      if (!settings.handoffConfiguration) {
+        throw new Error("Handoff configuration not found");
+      }
 
-    const [SunshineConversationsClient, zendeskConversationsAppId] =
-      await getSunshineConversationsClient(settings.handoffConfiguration);
+      const [SunshineConversationsClient, zendeskConversationsAppId] =
+        await getSunshineConversationsClient(settings.handoffConfiguration);
 
-    await postMessagesToZendeskConversation(
-      SunshineConversationsClient,
-      conversationId,
-      userId,
-      zendeskConversationsAppId,
-      [
-        {
-          author: {
-            type: 'user',
+      await postMessagesToZendeskConversation(
+        SunshineConversationsClient,
+        conversationId,
+        userId,
+        zendeskConversationsAppId,
+        [
+          {
+            author: {
+              type: "user",
+            },
+            content: {
+              type: "text",
+              text: message,
+            },
           },
-          content: {
-            type: 'text',
-            text: message,
-          },
-        },
-      ]
-    );
+        ],
+      );
 
-    return NextResponse.json({ success: true });
-  });
+      return NextResponse.json({ success: true });
+    },
+  );
 }
 
 export async function GET(request: NextRequest) {
   return withSettingsAndAuthentication(
     request,
-    async (_req, _settings, _organizationId, _agentId, _userId, conversationId) => {
+    async (
+      _req,
+      _settings,
+      _organizationId,
+      _agentId,
+      _userId,
+      conversationId,
+    ) => {
       const encoder = new TextEncoder();
       const pattern = `zendesk:${conversationId}:*`;
+      const redisClient = await getRedisClient();
       const stream = new ReadableStream({
         async start(controller) {
           try {
-            if (!redisClient.isOpen) {
-              await redisClient.connect();
-            }
-
             await redisClient.pSubscribe(pattern, (message, channel) => {
               try {
                 const parsedMessage = JSON.parse(message);
                 controller.enqueue(
                   encoder.encode(
-                    `data: ${JSON.stringify({ message: parsedMessage, channel })}\n\n`
-                  )
+                    `data: ${JSON.stringify({ message: parsedMessage, channel })}\n\n`,
+                  ),
                 );
               } catch (error) {
-                console.error('Error processing subscription message:', error);
+                console.error("Error processing subscription message:", error);
               }
             });
           } catch (error) {
-            console.error('Error streaming messages:', error);
+            console.error("Error streaming messages:", error);
             controller.error(error);
           }
         },
@@ -76,12 +83,12 @@ export async function GET(request: NextRequest) {
 
       return new Response(stream, {
         headers: {
-          'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache',
-          Connection: 'keep-alive',
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
         },
       });
-    }
+    },
   );
 }
 

--- a/app/api/zendesk/webhook/route.ts
+++ b/app/api/zendesk/webhook/route.ts
@@ -1,12 +1,12 @@
-import { type NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
-import redisClient from '@/app/api/server/lib/redis';
+import { type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getRedisClient } from "@/app/api/server/lib/redis";
 
-const ZENDESK_CONVERSATION_EVENT_TYPE_PREFIX = 'conversation:';
+const ZENDESK_CONVERSATION_EVENT_TYPE_PREFIX = "conversation:";
 
 export const POST = async (request: NextRequest) => {
   const body = await request.json();
-  for (const event of (body.events || [])) {
+  for (const event of body.events || []) {
     if (!event.type.startsWith(ZENDESK_CONVERSATION_EVENT_TYPE_PREFIX)) {
       continue;
     }
@@ -18,9 +18,11 @@ export const POST = async (request: NextRequest) => {
       continue;
     }
 
+    const redisClient = await getRedisClient();
+
     await redisClient.publish(
       `zendesk:${conversationId}:${eventId}`,
-      JSON.stringify(event)
+      JSON.stringify(event),
     );
   }
 


### PR DESCRIPTION
Context: Our Zendesk webhook was subscribing to events before the redis client connected.

This PR moves the "wait for connection" call to the redis dependency rather than the webhook route.