### PR TITLE
fix: create separate publish and subscribe clients

### DIFF
--- a/app/api/server/lib/redis.ts
+++ b/app/api/server/lib/redis.ts
@@ -1,13 +1,15 @@
 import { createClient } from "redis";
 
 // Create a Redis client factory
-const createRedisClient = async () => {
+const createRedisClient = async (mode?: "Publish" | "Subscribe") => {
   const client = createClient({
     url: process.env.STORAGE_REDIS_URL,
   });
 
-  client.on("error", (err) => console.error("Redis Client Error", err));
-  client.on("ready", () => console.log("Redis Client Ready"));
+  client.on("error", (err) =>
+    console.error("Redis Client Error", { mode }, err),
+  );
+  client.on("ready", () => console.log("Redis Client Ready", { mode }));
 
   await client.connect();
 
@@ -15,12 +17,20 @@ const createRedisClient = async () => {
 };
 
 const globalForRedis = global as unknown as {
-  redis: ReturnType<typeof createClient> | undefined;
+  redisPublish: ReturnType<typeof createClient> | undefined;
+  redisSubscribe: ReturnType<typeof createClient> | undefined;
 };
 
-export const getRedisClient = async () => {
-  if (!globalForRedis.redis) {
-    globalForRedis.redis = await createRedisClient();
+export const getRedisPublishClient = async () => {
+  if (!globalForRedis.redisPublish) {
+    globalForRedis.redisPublish = await createRedisClient("Publish");
   }
-  return globalForRedis.redis;
+  return globalForRedis.redisPublish;
+};
+
+export const getRedisSubscribeClient = async () => {
+  if (!globalForRedis.redisSubscribe) {
+    globalForRedis.redisSubscribe = await createRedisClient("Subscribe");
+  }
+  return globalForRedis.redisSubscribe;
 };

--- a/app/api/zendesk/messages/route.ts
+++ b/app/api/zendesk/messages/route.ts
@@ -5,7 +5,7 @@ import {
   postMessagesToZendeskConversation,
 } from "@/app/api/zendesk/utils";
 import { withSettingsAndAuthentication } from "@/app/api/server/utils";
-import { getRedisClient } from "@/app/api/server/lib/redis";
+import { getRedisSubscribeClient } from "@/app/api/server/lib/redis";
 import type { ZendeskMessagePayload } from "@/types/zendesk";
 
 const KEEP_ALIVE_INTERVAL = 30000;
@@ -67,7 +67,7 @@ export async function GET(request: NextRequest) {
       }
 
       const pattern = `zendesk:${conversationId}:${webhookId}:*`;
-      const redisClient = await getRedisClient();
+      const redisClient = await getRedisSubscribeClient();
 
       let keepAliveInterval: NodeJS.Timeout;
 

--- a/app/api/zendesk/webhook/route.ts
+++ b/app/api/zendesk/webhook/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getRedisClient } from "@/app/api/server/lib/redis";
+import { getRedisPublishClient } from "@/app/api/server/lib/redis";
 import type { ZendeskMessagePayload } from "@/types/zendesk";
 
 const ZENDESK_CONVERSATION_EVENT_TYPE_PREFIX = "conversation:";
@@ -24,7 +24,7 @@ export const POST = async (request: NextRequest) => {
       continue;
     }
 
-    const redisClient = await getRedisClient();
+    const redisClient = await getRedisPublishClient();
 
     await redisClient.publish(
       `zendesk:${conversationId}:${webhookId}:${eventId}`,


### PR DESCRIPTION
Update to resolve the error `ERR Can't execute 'publish': only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context`


According to this [SO answer](https://stackoverflow.com/a/51585392), a client can only subscribe or publish but not both at the same time