### PR TITLE
APP-749: add front client code to sync conversations that were not escalated to an agent

### DIFF
--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -11,7 +11,7 @@ export class FrontCoreClient {
     private host: string = DEFAULT_API_HOST,
   ) {}
 
-  private async fetchPagedResource<T>(
+  private async fetchPagedResource<T extends Front.PagedResource>(
     resource: string,
     params?: Front.PagedEndpointParams,
   ) {

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -46,10 +46,7 @@ export class FrontCoreClient {
   }
 
   public async importMessage(inboxId: string, message: Front.ImportedMessage) {
-    let url: string | URL = new URL(
-      `/inboxes/${inboxId}/imported_messages`,
-      this.host,
-    );
+    const url = new URL(`/inboxes/${inboxId}/imported_messages`, this.host);
 
     return await jsonFetch<Front.ImportMessageResponse>(url, {
       method: "POST",

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -44,6 +44,21 @@ export class FrontCoreClient {
   public async inboxes(params?: Front.PagedEndpointParams) {
     return await this.fetchPagedResource<Front.Inbox>("/inboxes", params);
   }
+
+  public async importMessage(inboxId: string, message: Front.ImportedMessage) {
+    let url: string | URL = new URL(
+      `/inboxes/${inboxId}/imported_messages`,
+      this.host,
+    );
+
+    return await jsonFetch<Front.ImportMessageResponse>(url, {
+      method: "POST",
+      body: JSON.stringify(message),
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+  }
 }
 
 export class FrontApplicationClient {

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -40,6 +40,10 @@ export class FrontCoreClient {
   public async channels(params?: Front.PagedEndpointParams) {
     return await this.fetchPagedResource<Front.Channel>("/channels", params);
   }
+
+  public async inboxes(params?: Front.PagedEndpointParams) {
+    return await this.fetchPagedResource<Front.Inbox>("/inboxes", params);
+  }
 }
 
 export class FrontApplicationClient {

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -11,9 +11,12 @@ export class FrontCoreClient {
     private host: string = DEFAULT_API_HOST,
   ) {}
 
-  public async channels(params?: Front.PagedEndpointParams) {
+  private async fetchPagedResource<T>(
+    resource: string,
+    params?: Front.PagedEndpointParams,
+  ) {
     const { next, limit = 10 } = params ?? {};
-    let url: string | URL = new URL("/channels", this.host);
+    let url: string | URL = new URL(resource, this.host);
     if (next) {
       url = next;
     } else {
@@ -26,12 +29,16 @@ export class FrontCoreClient {
 
       url.search = queryParams.toString();
     }
-    return await jsonFetch<Front.List<Front.Channel>>(url, {
+    return await jsonFetch<Front.List<T>>(url, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
       },
     });
+  }
+
+  public async channels(params?: Front.PagedEndpointParams) {
+    return await this.fetchPagedResource<Front.Channel>("/channels", params);
   }
 }
 

--- a/app/api/front/utils.ts
+++ b/app/api/front/utils.ts
@@ -112,6 +112,23 @@ async function findChannel(client: FrontCoreClient, channelName: string) {
   return channel;
 }
 
+export async function findInbox(client: FrontCoreClient, inboxName: string) {
+  let next: string | null = null;
+  let inbox: Front.Inbox | null | undefined = null;
+
+  while (!inbox) {
+    const inboxes = await client.inboxes({ next });
+    inbox = inboxes._results.find((channel) => channel.name === inboxName);
+
+    if (inbox || !inboxes._pagination.next) {
+      break;
+    }
+    next = inboxes._pagination.next;
+  }
+
+  return inbox;
+}
+
 export async function createApplicationChannelClient(
   config: FrontHandoffConfiguration,
 ) {

--- a/app/api/front/utils.ts
+++ b/app/api/front/utils.ts
@@ -7,6 +7,14 @@ import { Cacheable, KeyvCacheableMemory } from "cacheable";
 import { getRedisCache } from "@/app/api/server/lib/redis";
 import { JsonFetchError } from "@/lib/jsonFetch";
 import Bottleneck from "bottleneck";
+enum RetryableStatusCodes {
+  TooManyRequests = 429,
+  InternalServerError = 500,
+  NotImplemented = 501,
+  BadGateway = 502,
+  ServiceUnavailable = 503,
+  GatewayTimeout = 504,
+}
 
 let channelCache: Cacheable | undefined;
 async function getChannelCache() {
@@ -156,14 +164,6 @@ export async function postMavenMessagesToFront({
     minTime: 200, // 5 requests per second per conversation
   });
   frontLimiter.on("failed", async (error, info) => {
-    enum RetryableStatusCodes {
-      TooManyRequests = 429,
-      InternalServerError = 500,
-      NotImplemented = 501,
-      BadGateway = 502,
-      ServiceUnavailable = 503,
-      GatewayTimeout = 504,
-    }
     const { retryCount } = info;
     const backoffs = [0.2, 0.4, 0.8, 1, 2];
     if (

--- a/types/front/index.ts
+++ b/types/front/index.ts
@@ -4,6 +4,8 @@ export namespace Front {
     message_uid: string;
   };
 
+  export type ImportMessageResponse = AppChannelSyncResponse;
+
   export type AppChannelBaseMessage = {
     body: string;
     metadata: Metadata;
@@ -123,6 +125,15 @@ export namespace Front {
     webhook_url: string;
   };
 
+  export type Inbox = {
+    _links: Links;
+    address: string;
+    id: string;
+    name: string;
+    send_as: string;
+    type: string;
+  };
+
   export type Pagination = {
     limit: number;
     next: string | null;
@@ -137,5 +148,32 @@ export namespace Front {
   export type PagedEndpointParams = {
     next?: string | null;
     limit?: number;
+  };
+
+  export type ImportedMessage = {
+    sender: {
+      author_id?: string;
+      handle: string;
+      name?: string;
+    };
+    body_format?: "html" | "markdown";
+    type?: "email";
+    metadata: {
+      thread_ref?: string;
+      is_inbound: boolean;
+      should_skip_rules?: boolean;
+      is_archived?: boolean;
+    };
+    assignee_id?: string;
+    attachments?: string[];
+    to: string[];
+    tags?: string[];
+    cc?: string[];
+    bcc?: string[];
+    subject?: string;
+    body: string;
+    external_id: string;
+    created_at: number;
+    conversation_id?: string;
   };
 }

--- a/types/front/index.ts
+++ b/types/front/index.ts
@@ -1,4 +1,6 @@
 export namespace Front {
+  export type PagedResource = {};
+
   export type AppChannelSyncResponse = {
     status: string;
     message_uid: string;
@@ -111,7 +113,7 @@ export namespace Front {
     };
   };
 
-  export type Channel = {
+  export type Channel = PagedResource & {
     _links: Links;
     address: string;
     id: string;
@@ -125,7 +127,7 @@ export namespace Front {
     webhook_url: string;
   };
 
-  export type Inbox = {
+  export type Inbox = PagedResource & {
     _links: Links;
     address: string;
     id: string;
@@ -139,7 +141,7 @@ export namespace Front {
     next: string | null;
     prev?: string;
   };
-  export type List<T> = {
+  export type List<T extends PagedResource> = {
     _pagination: Pagination;
     _links: Omit<Links, "related">;
     _results: T[];


### PR DESCRIPTION
Add client methods that will be used to import messages for a conversation that was not escalated to an agent... coming up in a follow up PR