### PR TITLE
APP-749: setup boilerplate to sync conversation that didn't escalate to an agent

### DIFF
--- a/app/api/front/conversations/unabridged/route.ts
+++ b/app/api/front/conversations/unabridged/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withAppSettings } from "@/app/api/server/utils";
+
+export async function POST(request: NextRequest) {
+  return withAppSettings(
+    request,
+    async (_request, settings, _organizationId, _agentId) => {
+      // NOTE: request to this endpoint use keepalive: true and must remain under 1024 kibibytes
+      // https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#keepalive
+      // TODO: fetch messages from maven client to keep the request size small
+      if (settings.handoffConfiguration?.type !== "front") {
+        return NextResponse.json(
+          { error: "Front Handoff configuration not found or invalid" },
+          { status: 400 },
+        );
+      }
+
+      return NextResponse.json({ success: true });
+    },
+  );
+}

--- a/app/api/zendesk/conversations/unabridged/route.ts
+++ b/app/api/zendesk/conversations/unabridged/route.ts
@@ -1,0 +1,20 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withAppSettings } from "@/app/api/server/utils";
+
+export async function POST(request: NextRequest) {
+  return withAppSettings(
+    request,
+    async (_request, settings, _organizationId, _agentId) => {
+      // NOTE: request to this endpoint use keepalive: true and must remain under 1024 kibibytes
+      // https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#keepalive
+      if (settings.handoffConfiguration?.type !== "zendesk") {
+        return NextResponse.json(
+          { error: "Front Handoff configuration not found or invalid" },
+          { status: 400 },
+        );
+      }
+
+      return NextResponse.json({ success: true });
+    },
+  );
+}

--- a/lib/useHandoff.ts
+++ b/lib/useHandoff.ts
@@ -442,5 +442,7 @@ export function useHandoff({ messages, mavenConversationId }: HandoffProps) {
     askHandoff,
     handleEndHandoff,
     isConnected,
+    handoffType: handoffTypeRef.current,
+    handoffAuthToken,
   };
 }


### PR DESCRIPTION
## Context
Scratchpay wants to see all conversation in Front... even the ones that never escalated to an agent

## Approach
To keep this custom functionality from permeating through the rest of the app, I'm syncing unescalated/unabridged conversation to Front using `onbeforeunload`. When a user leaves that experience, the `/unabridged` endpoint will be called to sync the conversation

Let me know your thoughts on the approach. Conversation syncing coming up in a separate PR