### PR TITLE
feat: add properties to widget-to-iframe communication

### DIFF
--- a/__tests__/app/[orgFriendlyId]/[id]/page.test.tsx
+++ b/__tests__/app/[orgFriendlyId]/[id]/page.test.tsx
@@ -1,13 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import ChatPage from "@/app/[orgFriendlyId]/[id]/page";
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
-import { HandoffChatMessage, Message } from "@/types";
+import {
+  ChatEndedMessage,
+  ChatEstablishedMessage,
+  Message,
+  UserChatMessage,
+  ZendeskWebhookMessage,
+} from "@/types";
+import { Front } from "@/types/front";
 import { HandoffStatus } from "@/app/constants/handoff";
 import { useChat } from "@magi/components/chat/use-chat";
 import { useHandoff } from "@/lib/useHandoff";
 
 let chatMessages = [] as Message[];
-let handoffMessages = [] as HandoffChatMessage[];
+let handoffMessages = [] as (
+  | ZendeskWebhookMessage
+  | Front.WebhookMessage
+  | ChatEstablishedMessage
+  | UserChatMessage
+  | ChatEndedMessage
+)[];
 
 vi.mock("@magi/components/chat/use-chat");
 const useChatMock = vi.mocked(useChat);
@@ -46,10 +59,14 @@ describe("ChatPage", () => {
       isResponseAvailable: false,
       askQuestion: vi.fn(),
       conversationId: "test-conversation-id",
+      mavenUserId: "test-maven-user-id",
     });
 
     useHandoffMock.mockReturnValue({
-      ...useHandoffMock({ messages: chatMessages }),
+      ...useHandoffMock({
+        messages: chatMessages,
+        mavenConversationId: "test-maven-conversation-id",
+      }),
       handoffChatEvents: handoffMessages,
       initializeHandoff: vi.fn(),
       agentName: "Lenny",
@@ -124,7 +141,10 @@ describe("ChatPage", () => {
       });
 
       useHandoffMock.mockReturnValue({
-        ...useHandoffMock({ messages: chatMessages }),
+        ...useHandoffMock({
+          messages: chatMessages,
+          mavenConversationId: "test-maven-conversation-id",
+        }),
         handoffChatEvents: handoffMessages,
       });
     });

--- a/__tests__/app/demo/[orgFriendlyId]/[agentFriendlyId]/page.test.tsx
+++ b/__tests__/app/demo/[orgFriendlyId]/[agentFriendlyId]/page.test.tsx
@@ -74,13 +74,27 @@ describe("DemoPage", () => {
       expect(scripts[0]).toHaveAttribute("defer");
 
       // Check if widget load script contains correct payload
-      const expectedPayload = {
-        envPrefix: "test-prefix",
-        orgFriendlyId: "test-org",
-        agentFriendlyId: "test-agent",
-        bgColor: "#123456",
-      };
-      expect(scripts[1].innerHTML).toContain(JSON.stringify(expectedPayload));
+      const payloadRegex = `addEventListener\\("load", function \\(\\) {
+        Maven\\.ChatWidget\\.load\\({
+          "envPrefix":"[^"]+",
+          "orgFriendlyId":"[^"]+",
+          "agentFriendlyId":"[^"]+",
+          "bgColor":"#[0-9a-fA-F]{6}",
+          "unsignedUserData":{
+            "firstName":"[^"]+",
+            "lastName":"[^"]+",
+            "id":"[^"]+",
+            "email":"[^"]+"
+          },
+          "customData":{
+            "buttonId":"[^"]+"
+          }
+        }\\);
+      }\\);`.replace(/\s+/g, "");
+
+      expect(scripts[1].innerHTML.replace(/\s+/g, "")).toMatch(
+        new RegExp(payloadRegex),
+      );
     });
   });
 

--- a/app/[orgFriendlyId]/[id]/__tests__/page.test.tsx
+++ b/app/[orgFriendlyId]/[id]/__tests__/page.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ChatPageWrapper from "../page";
+import { useIframeMessaging } from "@/lib/useIframeMessaging";
+import { useChat } from "@magi/components/chat/use-chat";
+import { useHandoff } from "@/lib/useHandoff";
+import { HandoffStatus } from "@/app/constants/handoff";
+import { useParams } from "next/navigation";
+import { useAnalytics } from "@/lib/use-analytics";
+import { MagiEvent } from "@/lib/analytics/events";
+import type { Message } from "@/types";
+
+// Mock all the hooks and dependencies
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+}));
+
+vi.mock("@/lib/useIframeMessaging", () => ({
+  useIframeMessaging: vi.fn(),
+}));
+
+vi.mock("@magi/components/chat/use-chat", () => ({
+  useChat: vi.fn(),
+}));
+
+vi.mock("@/lib/useHandoff", () => ({
+  useHandoff: vi.fn(),
+}));
+
+vi.mock("@/lib/use-analytics", () => ({
+  useAnalytics: vi.fn(),
+}));
+
+vi.mock("@/app/providers/SettingsProvider", () => ({
+  useSettings: () => ({
+    brandColor: "#000000",
+    logoUrl: "test-logo.png",
+  }),
+}));
+
+describe("ChatPage", () => {
+  beforeEach(() => {
+    // Setup default mock implementations
+    vi.mocked(useParams).mockReturnValue({
+      orgFriendlyId: "test-org",
+      id: "test-id",
+    });
+
+    vi.mocked(useIframeMessaging).mockReturnValue({
+      loading: false,
+      signedUserData: null,
+      unsignedUserData: null,
+      customData: {},
+    });
+
+    vi.mocked(useChat).mockReturnValue({
+      messages: [],
+      isLoading: false,
+      isResponseAvailable: false,
+      askQuestion: vi.fn(),
+      conversationId: "test-conversation",
+      mavenUserId: "test-user",
+    });
+
+    vi.mocked(useHandoff).mockReturnValue({
+      initializeHandoff: vi.fn(),
+      handoffChatEvents: [],
+      agentName: "",
+      handoffStatus: HandoffStatus.NOT_INITIALIZED,
+      askHandoff: vi.fn(),
+      handleEndHandoff: vi.fn(),
+      handoffError: null,
+      isConnected: false,
+    });
+
+    vi.mocked(useAnalytics).mockReturnValue({
+      logEvent: vi.fn(),
+      init: vi.fn(),
+    });
+  });
+
+  it("renders the chat page with welcome message", () => {
+    render(<ChatPageWrapper />);
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+  });
+
+  it("shows loading state correctly", () => {
+    vi.mocked(useIframeMessaging).mockReturnValue({
+      loading: true,
+      signedUserData: null,
+      unsignedUserData: null,
+      customData: {},
+    });
+
+    const { container } = render(<ChatPageWrapper />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("logs analytics event on mount", () => {
+    const mockLogEvent = vi.fn();
+    vi.mocked(useAnalytics).mockReturnValue({
+      logEvent: mockLogEvent,
+      init: vi.fn(),
+    });
+
+    render(<ChatPageWrapper />);
+
+    expect(mockLogEvent).toHaveBeenCalledWith(MagiEvent.chatHomeView, {
+      agentId: "test-id",
+    });
+  });
+
+  it("handles handoff state correctly", () => {
+    vi.mocked(useHandoff).mockReturnValue({
+      initializeHandoff: vi.fn(),
+      handoffChatEvents: [],
+      agentName: "Test Agent",
+      handoffStatus: HandoffStatus.INITIALIZED,
+      askHandoff: vi.fn(),
+      handleEndHandoff: vi.fn(),
+      handoffError: null,
+      isConnected: true,
+    });
+
+    render(<ChatPageWrapper />);
+    expect(screen.getByText("Test Agent")).toBeInTheDocument();
+  });
+
+  it("combines and sorts messages correctly", () => {
+    const chatMessages: Message[] = [
+      {
+        conversationMessageId: "1",
+        text: "Message 1",
+        type: "USER",
+        timestamp: 1000,
+        attachments: [],
+        userId: "test-user",
+        userMessageType: "text",
+      },
+      {
+        conversationMessageId: "2",
+        text: "Message 2",
+        type: "bot",
+        timestamp: 2000,
+        attachments: [],
+        userId: "test-user",
+        userMessageType: "text",
+      },
+    ];
+
+    const handoffEvents = [
+      {
+        type: "chat_established",
+        agentName: "Agent",
+        timestamp: 1500,
+        conversationId: "test-conv",
+      },
+    ];
+
+    vi.mocked(useChat).mockReturnValue({
+      messages: chatMessages,
+      isLoading: false,
+      isResponseAvailable: false,
+      askQuestion: vi.fn(),
+      conversationId: "test-conversation",
+      mavenUserId: "test-user",
+    });
+
+    vi.mocked(useHandoff).mockReturnValue({
+      initializeHandoff: vi.fn(),
+      handoffChatEvents: handoffEvents,
+      agentName: "",
+      handoffStatus: HandoffStatus.NOT_INITIALIZED,
+      askHandoff: vi.fn(),
+      handleEndHandoff: vi.fn(),
+      handoffError: null,
+      isConnected: false,
+    });
+
+    render(<ChatPageWrapper />);
+
+    const messageElements = screen.getAllByRole("listitem");
+    expect(messageElements).toHaveLength(3);
+    expect(messageElements[0]).toHaveTextContent("Message 1");
+    expect(messageElements[1]).toHaveTextContent("Handoff 1");
+    expect(messageElements[2]).toHaveTextContent("Message 2");
+  });
+
+  it("shows powered by Maven when no messages", () => {
+    vi.mocked(useChat).mockReturnValue({
+      messages: [],
+      isLoading: false,
+      isResponseAvailable: false,
+      askQuestion: vi.fn(),
+      conversationId: "test-conversation",
+      mavenUserId: "test-user",
+    });
+
+    render(<ChatPageWrapper />);
+    expect(screen.getByTestId("powered-by-maven")).toBeInTheDocument();
+  });
+});

--- a/app/[orgFriendlyId]/[id]/page.tsx
+++ b/app/[orgFriendlyId]/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useAnalytics } from "@/lib/use-analytics";
 import { useSettings } from "@/app/providers/SettingsProvider";
 import { useIframeMessaging } from "@/lib/useIframeMessaging";
 import { AuthProvider } from "@/app/providers/AuthProvider";
+import { CustomDataProvider } from "@/app/providers/CustomDataProvider";
 import { ChatHeader } from "@magi/components/chat/ChatHeader";
 import { WelcomeMessage } from "@magi/components/chat/WelcomeChatMessage";
 import { ChatMessages } from "@magi/components/chat/ChatMessages";
@@ -128,13 +129,19 @@ function ChatPage() {
 }
 
 export default function ChatPageWrapper() {
-  const { loading, signedUserData } = useIframeMessaging();
+  const { loading, signedUserData, unsignedUserData, customData } =
+    useIframeMessaging();
 
   if (loading) return null;
 
   return (
-    <AuthProvider signedUserData={signedUserData}>
-      <ChatPage />
+    <AuthProvider
+      signedUserData={signedUserData}
+      unsignedUserData={unsignedUserData}
+    >
+      <CustomDataProvider customData={customData}>
+        <ChatPage />
+      </CustomDataProvider>
     </AuthProvider>
   );
 }

--- a/app/demo/[orgFriendlyId]/[agentFriendlyId]/page.tsx
+++ b/app/demo/[orgFriendlyId]/[agentFriendlyId]/page.tsx
@@ -51,6 +51,10 @@ export default async function Page({
     agentFriendlyId,
     bgColor: brandColor || "#00202b",
     signedUserData: signedUserData || undefined,
+    unsignedUserData: mockUserData,
+    customData: {
+      buttonId: "123",
+    },
   };
 
   return (

--- a/app/providers/AuthProvider.tsx
+++ b/app/providers/AuthProvider.tsx
@@ -7,6 +7,7 @@ import React, {
 
 type AuthContextType = {
   signedUserData: string | null;
+  unsignedUserData: Record<string, any> | null;
   isAuthenticated: boolean;
 } | null;
 
@@ -14,13 +15,16 @@ const AuthContext = createContext<AuthContextType>(null);
 
 export const AuthProvider = ({
   signedUserData,
+  unsignedUserData,
   children,
 }: PropsWithChildren<{
   signedUserData: string | null;
+  unsignedUserData: Record<string, any> | null;
 }>) => {
   const isAuthenticated = useMemo(() => !!signedUserData, [signedUserData]);
   const value = {
     signedUserData,
+    unsignedUserData,
     isAuthenticated,
   };
 

--- a/app/providers/CustomDataProvider.tsx
+++ b/app/providers/CustomDataProvider.tsx
@@ -1,0 +1,36 @@
+import React, {
+  createContext,
+  useContext,
+  type PropsWithChildren,
+} from "react";
+
+type CustomDataContextType = {
+  customData: Record<string, any> | null;
+} | null;
+
+const CustomDataContext = createContext<CustomDataContextType>(null);
+
+export const CustomDataProvider = ({
+  customData,
+  children,
+}: PropsWithChildren<{
+  customData: Record<string, any> | null;
+}>) => {
+  const value = {
+    customData,
+  };
+
+  return (
+    <CustomDataContext.Provider value={value}>
+      {children}
+    </CustomDataContext.Provider>
+  );
+};
+
+export function useCustomData() {
+  const context = useContext(CustomDataContext);
+  if (context === null) {
+    throw new Error("useCustomData must be used within an CustomDataProvider");
+  }
+  return context;
+}

--- a/lib/useIframeMessaging.ts
+++ b/lib/useIframeMessaging.ts
@@ -7,6 +7,8 @@ interface LegacyMessageEvent extends MessageEvent {
 
 enum MAVEN_MESSAGE_TYPES {
   SIGNED_USER_DATA = "SIGNED_USER_DATA",
+  UNSIGNED_USER_DATA = "UNSIGNED_USER_DATA",
+  CUSTOM_DATA = "CUSTOM_DATA",
   MAVEN_LOADED = "MAVEN_LOADED",
 }
 
@@ -16,6 +18,13 @@ const demoUrl = (orgFriendlyId: string, agentFriendlyId: string) =>
 export function useIframeMessaging() {
   const [loading, setLoading] = useState(true);
   const [signedUserData, setSignedUserData] = useState<string | null>(null);
+  const [unsignedUserData, setUnsignedUserData] = useState<Record<
+    string,
+    any
+  > | null>(null);
+  const [customData, setCustomData] = useState<Record<string, any> | null>(
+    null,
+  );
   const {
     orgFriendlyId,
     id: agentFriendlyId,
@@ -29,6 +38,12 @@ export function useIframeMessaging() {
     switch (data.type) {
       case MAVEN_MESSAGE_TYPES.SIGNED_USER_DATA:
         setSignedUserData(data.data);
+        break;
+      case MAVEN_MESSAGE_TYPES.UNSIGNED_USER_DATA:
+        setUnsignedUserData(data.data);
+        break;
+      case MAVEN_MESSAGE_TYPES.CUSTOM_DATA:
+        setCustomData(data.data);
         break;
       default:
         break;
@@ -65,5 +80,7 @@ export function useIframeMessaging() {
   return {
     loading,
     signedUserData,
+    unsignedUserData,
+    customData,
   };
 }

--- a/packages/widget/src/chat/hooks/useIframeCommunication.ts
+++ b/packages/widget/src/chat/hooks/useIframeCommunication.ts
@@ -9,6 +9,8 @@ import {
 enum MAVEN_MESSAGE_TYPES {
   USER_DATA = "USER_DATA",
   SIGNED_USER_DATA = "SIGNED_USER_DATA",
+  UNSIGNED_USER_DATA = "UNSIGNED_USER_DATA",
+  CUSTOM_DATA = "CUSTOM_DATA",
   MAVEN_LOADED = "MAVEN_LOADED",
 }
 
@@ -16,6 +18,17 @@ type SignedUserDataMessage = {
   type: MAVEN_MESSAGE_TYPES.SIGNED_USER_DATA;
   data: string;
 };
+
+type UnsignedUserDataMessage = {
+  type: MAVEN_MESSAGE_TYPES.UNSIGNED_USER_DATA;
+  data: Record<string, any>;
+};
+
+type CustomDataMessage = {
+  type: MAVEN_MESSAGE_TYPES.CUSTOM_DATA;
+  data: Record<string, any>;
+};
+
 interface LegacyMessageEvent extends MessageEvent {
   message?: any; // Support for older browsers
 }
@@ -24,18 +37,24 @@ export function useIframeCommunication({
   orgFriendlyId,
   agentFriendlyId,
   signedUserData,
+  unsignedUserData,
+  customData,
   isWide,
   isOpen,
 }: {
   orgFriendlyId: string;
   agentFriendlyId: string;
   signedUserData?: string | null;
+  unsignedUserData?: Record<string, any> | null;
+  customData?: Record<string, any> | null;
   isWide: boolean;
   isOpen: boolean;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const messageQueue = useRef<SignedUserDataMessage[]>([]);
+  const messageQueue = useRef<
+    (SignedUserDataMessage | UnsignedUserDataMessage | CustomDataMessage)[]
+  >([]);
 
   const iframeUrl = useMemo((): string => {
     const currentDomain = window.location.hostname;
@@ -72,7 +91,12 @@ export function useIframeCommunication({
   }, [isWide, isOpen]);
 
   const postMessageToIframe = useCallback(
-    (message: SignedUserDataMessage) => {
+    (
+      message:
+        | SignedUserDataMessage
+        | UnsignedUserDataMessage
+        | CustomDataMessage,
+    ) => {
       if (isLoaded && iframeRef.current?.contentWindow) {
         iframeRef.current.contentWindow.postMessage(message, "*");
       } else {
@@ -83,12 +107,31 @@ export function useIframeCommunication({
   );
 
   useEffect(() => {
-    if (signedUserData) {
-      postMessageToIframe({
+    const messages = [
+      {
         type: MAVEN_MESSAGE_TYPES.SIGNED_USER_DATA,
         data: signedUserData,
-      });
-    }
+      },
+      {
+        type: MAVEN_MESSAGE_TYPES.UNSIGNED_USER_DATA,
+        data: unsignedUserData,
+      },
+      {
+        type: MAVEN_MESSAGE_TYPES.CUSTOM_DATA,
+        data: customData,
+      },
+    ];
+
+    messages.forEach((message) => {
+      if (message.data) {
+        postMessageToIframe(
+          message as
+            | SignedUserDataMessage
+            | UnsignedUserDataMessage
+            | CustomDataMessage,
+        );
+      }
+    });
   }, [postMessageToIframe]);
 
   useEffect(() => {

--- a/packages/widget/src/chat/index.tsx
+++ b/packages/widget/src/chat/index.tsx
@@ -23,6 +23,9 @@ type Props = {
   horizontalPosition: "left" | "right";
   verticalPosition: "top" | "bottom";
   signedUserData?: string | null;
+  unsignedUserData?: Record<string, any> | null;
+  unverifiedUserData?: Record<string, any> | null;
+  customData?: Record<string, any> | null;
   orgFriendlyId: string;
   agentFriendlyId: string;
 };
@@ -34,6 +37,8 @@ const App = forwardRef<{ open: () => void; close: () => void }, Props>(
       orgFriendlyId: props.orgFriendlyId,
       agentFriendlyId: props.agentFriendlyId,
       signedUserData: props.signedUserData,
+      unsignedUserData: props.unsignedUserData || props.unverifiedUserData,
+      customData: props.customData,
       isWide,
       isOpen,
     });
@@ -83,6 +88,8 @@ export async function load({
   orgFriendlyId,
   agentFriendlyId,
   signedUserData = null,
+  unsignedUserData = null,
+  customData = null,
 }: Partial<Omit<Props, "agentId" | "baseUrl">> & {
   envPrefix?: string;
   apiKey: string;
@@ -91,6 +98,8 @@ export async function load({
   orgFriendlyId: string;
   agentFriendlyId: string;
   signedUserData?: string | null;
+  unsignedUserData?: Record<string, any> | null;
+  customData?: Record<string, any> | null;
 }) {
   const placeholder = document.createElement("div");
   placeholder.id = "maven-chat-widget";
@@ -105,6 +114,8 @@ export async function load({
       horizontalPosition={horizontalPosition}
       verticalPosition={verticalPosition}
       signedUserData={signedUserData}
+      unsignedUserData={unsignedUserData}
+      customData={customData}
       orgFriendlyId={orgFriendlyId}
       agentFriendlyId={agentFriendlyId}
     />,


### PR DESCRIPTION
# Pass Additional Properties to Iframe

## Overview
This PR adds support for passing unsigned user data and custom data through the iframe messaging system, enabling better user identification and customization options in the chat widget.

## Key Changes

### New Message Types
- Added `UNSIGNED_USER_DATA` and `CUSTOM_DATA` message types for iframe communication
- These complement the existing `SIGNED_USER_DATA` type for a more complete user data handling system

### Data Flow
1. Widget load now accepts:
   - `unsignedUserData`: For basic user info (name, email, etc.)
   - `customData`: For arbitrary custom properties
2. Data is passed through the iframe messaging system
3. Data is made available via context providers in the chat application

### Provider Updates
- Added `CustomDataProvider` to manage custom data throughout the app
- Updated `AuthProvider` to handle both signed and unsigned user data
- Both providers expose hooks (`useAuth`, `useCustomData`) for data access to child components

### Testing
- Updated existing tests to account for new data flow

## Migration Notes
- The change is backwards compatible - existing implementations will continue to work

## Related Issues
- Will allow for TA migration to chat app
