### PR TITLE
fix: don't override front configuration channel name

### DIFF
--- a/app/api/server/utils.ts
+++ b/app/api/server/utils.ts
@@ -40,7 +40,7 @@ export async function getAppSettings(
   const handoffConfiguration =
     settings?.handoffConfiguration as unknown as HandoffConfiguration;
   if (handoffConfiguration?.type === "front") {
-    handoffConfiguration.channelName = `${organizationId}-${agentId}`;
+    handoffConfiguration.channelName ??= `${organizationId}-${agentId}`;
   }
 
   return settings as ParsedAppSettings;


### PR DESCRIPTION
To support testing against different maven branches (main, develop, local), there needs to be multiple instances of the same channel installed... To direct messages to the right instance, the configuration needs to be able to define the channel name.

This just checks to see if the value is already set... instead of always replacing