### PR TITLE
fix: update vercel prod url

### DIFF
--- a/app/api/front/route.ts
+++ b/app/api/front/route.ts
@@ -32,7 +32,9 @@ export const POST = async (request: NextRequest) => {
     agentId: agentId,
   });
   const host =
-    process.env.VERCEL_PRODUCTION_URL ??
+    (process.env.VERCEL_PROJECT_PRODUCTION_URL?.length
+      ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+      : null) ??
     process.env.LOCAL_DEV_TUNNEL_URL ??
     "http://localhost:3000";
   const url = new URL(host);


### PR DESCRIPTION
`VERCEL_PROJECT_PRODUCTION_URL` is the correct env. var to use to get the production URL

<img width="834" alt="Screenshot 2025-01-21 at 7 32 19 PM" src="https://github.com/user-attachments/assets/2fe316ee-d12b-4978-aeef-acfca3e9d567" />

