### PR TITLE
fix: scroll to bottom triggers on new message only

### DIFF
--- a/lib/useHandoff.ts
+++ b/lib/useHandoff.ts
@@ -23,7 +23,6 @@ import type {
 import { generateHeaders } from "./handoff/headerUtils";
 
 const HANDOFF_RECONNECT_INTERVAL = 500;
-const TYPING_INDICATOR_REFRESH_INTERVAL = 3000;
 
 const initialState: HandoffState = {
   handoffError: null,
@@ -49,7 +48,6 @@ export function useHandoff({
 
   // State
   const [state, setState] = useState<HandoffState>(initialState);
-  const [typingRefreshCounter, setTypingRefreshCounter] = useState(0);
   const handoffStatusRef = useRef<HandoffStatus>(state.handoffStatus);
 
   // Context hooks
@@ -328,23 +326,7 @@ export function useHandoff({
   }, []);
 
   const showTypingIndicator = useMemo(() => {
-    if (!state.agentName) {
-      return false;
-    }
-
-    return (
-      strategyRef.current?.showAgentTypingIndicator?.(
-        state.handoffChatEvents,
-      ) ?? false
-    );
-  }, [state.handoffChatEvents, typingRefreshCounter]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setTypingRefreshCounter((prev) => prev + 1);
-    }, TYPING_INDICATOR_REFRESH_INTERVAL);
-
-    return () => clearInterval(interval);
+    return false;
   }, []);
 
   const shouldSupressHandoffInputDisplay = useMemo(() => {

--- a/lib/useScrollToBottom.ts
+++ b/lib/useScrollToBottom.ts
@@ -18,7 +18,7 @@ export function useScrollToBottom<T extends HTMLElement>(): [
 
       observer.observe(container, {
         childList: true,
-        subtree: true,
+        subtree: false,
         attributes: false,
         characterData: false,
       });

--- a/packages/components/chat/ChatMessages.tsx
+++ b/packages/components/chat/ChatMessages.tsx
@@ -1,5 +1,3 @@
-import { forwardRef, RefObject } from "react";
-
 import { CombinedMessage } from "@/types";
 import { ChatMessage } from "@magi/components/chat/ChatMessage";
 import Spinner from "@magi/components/Spinner";


### PR DESCRIPTION
1. Updated the `useScrollToBottom` observer properties to only monitor for new elements in the chat messages list. Previously, it was traversing the sub tree and detecting any html changes, including markdown->html in message bodies.
2. Removed the timer that manages the typing indicator. We don't have proper requirements for it yet and it keeps re-rendering the component.
3. Removed an unused dep in `ChatMessages`