### PR TITLE
App 829 partial sf api

### DIFF
--- a/__tests__/app/api/salesforce/conversations/passControl/route.test.ts
+++ b/__tests__/app/api/salesforce/conversations/passControl/route.test.ts
@@ -1,0 +1,120 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { POST } from "@/app/api/salesforce/conversations/passControl/route";
+import { NextRequest, NextResponse } from "next/server";
+import { validateSalesforceConfig } from "@/app/api/salesforce/utils";
+
+// Mock external dependencies
+vi.mock("@/app/api/server/utils", () => ({
+  withSettingsAndAuthentication: vi.fn((req, handler) =>
+    handler(
+      req,
+      {
+        handoffConfiguration: {
+          type: "salesforce",
+          chatHostUrl: "https://test.salesforce.com",
+          apiSecret: "test-secret",
+        },
+      },
+      "test-org-id",
+      "test-agent-id",
+      "test-user-id",
+      "test-conversation-id",
+      {
+        affinityToken: "test-affinity-token",
+        sessionKey: "test-session-key",
+      },
+    ),
+  ),
+}));
+
+vi.mock("@/app/api/salesforce/utils", async () => {
+  const actual = await vi.importActual("@/app/api/salesforce/utils");
+  return {
+    ...(actual as object),
+    validateSalesforceConfig: vi.fn(),
+    validateAuthHeaders: vi.fn(),
+    generateSessionInitRequestHeaders: vi.fn(),
+  };
+});
+
+describe("POST /api/salesforce/conversations/passControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  const createMockRequest = () => ({
+    json: vi.fn().mockResolvedValue({}),
+  });
+
+  describe("Chat Session End", () => {
+    it("should successfully end chat session", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+      } as Response);
+
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ success: true });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://test.salesforce.com/chat/rest/System/SessionId/test-session-key",
+        expect.objectContaining({
+          method: "DELETE",
+        }),
+      );
+    });
+
+    it("should handle session end failure", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: false,
+      } as Response);
+
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Internal Server Error",
+      });
+    });
+
+    it("should handle network errors", async () => {
+      vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("Configuration Validation", () => {
+    it("should handle invalid configuration", async () => {
+      vi.mocked(validateSalesforceConfig).mockReturnValueOnce(
+        NextResponse.json(
+          { success: false, error: "Invalid Salesforce configuration" },
+          { status: 400 },
+        ),
+      );
+
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error: "Invalid Salesforce configuration",
+      });
+    });
+  });
+});

--- a/__tests__/app/api/salesforce/conversations/route.test.ts
+++ b/__tests__/app/api/salesforce/conversations/route.test.ts
@@ -1,0 +1,199 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import jwt from "jsonwebtoken";
+import { POST } from "@/app/api/salesforce/conversations/route";
+import { HANDOFF_AUTH_HEADER } from "@/app/constants/authentication";
+import { NextRequest } from "next/server";
+import { withAppSettings } from "@/app/api/server/utils";
+import { sendChatMessage } from "@/app/api/salesforce/utils";
+
+// Mock external dependencies
+vi.mock("jsonwebtoken", () => ({
+  default: { sign: vi.fn() },
+  sign: vi.fn(),
+}));
+
+vi.mock("@/app/api/server/utils", () => ({
+  withAppSettings: vi.fn((req, handler) =>
+    handler(
+      req,
+      {
+        handoffConfiguration: {
+          type: "salesforce",
+          chatHostUrl: "https://test.salesforce.com",
+          chatButtonId: "test-button-id",
+          deploymentId: "test-deployment-id",
+          orgId: "test-org-id",
+          eswLiveAgentDevName: "test-dev-name",
+          apiSecret: "test-secret",
+        },
+      },
+      "test-org-id",
+      "test-agent-id",
+    ),
+  ),
+}));
+
+vi.mock("@/app/api/salesforce/utils", async () => {
+  const actual = await vi.importActual("@/app/api/salesforce/utils");
+  return {
+    ...(actual as object),
+    sendChatMessage: vi.fn(),
+  };
+});
+
+describe("POST /api/salesforce/conversations", () => {
+  // Test fixtures
+  const TEST_DATA = {
+    SESSION_ID: "test-session-id",
+    SESSION_KEY: "test-session-key",
+    AFFINITY_TOKEN: "test-affinity-token",
+    JWT_TOKEN: "test-jwt-token",
+    DEFAULT_MESSAGE: { content: "Test message" },
+  };
+
+  const TEST_USER = {
+    firstName: "John",
+    lastName: "Doe",
+    email: "john@example.com",
+    userAgent: "test-user-agent",
+    screenResolution: "1920x1080",
+    language: "en-US",
+  };
+
+  // Helper to create mock request
+  const createMockRequest = ({
+    messages = [TEST_DATA.DEFAULT_MESSAGE],
+    unsignedUserData = TEST_USER,
+  } = {}) => ({
+    json: vi.fn().mockResolvedValue({
+      messages,
+      unsignedUserData,
+      userAgent: TEST_USER.userAgent,
+      screenResolution: TEST_USER.screenResolution,
+      language: TEST_USER.language,
+    }),
+  });
+
+  // Mock fetch responses
+  const mockFetchResponses = () => {
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes("/SessionId")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id: TEST_DATA.SESSION_ID,
+              key: TEST_DATA.SESSION_KEY,
+              affinityToken: TEST_DATA.AFFINITY_TOKEN,
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchResponses();
+    vi.mocked(jwt.sign).mockReturnValue(TEST_DATA.JWT_TOKEN);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Configuration Validation", () => {
+    it("should return 400 when handoff configuration type is invalid", async () => {
+      vi.mocked(withAppSettings).mockImplementationOnce((req, handler) =>
+        handler(
+          req,
+          {
+            handoffConfiguration: {
+              // @ts-expect-error - invalid type
+              type: "invalid",
+            },
+          },
+          "test-org-id",
+          "test-agent-id",
+        ),
+      );
+
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        success: false,
+        error: "Invalid handoff configuration type. Expected 'salesforce'.",
+      });
+    });
+  });
+
+  describe("Chat Session Initialization", () => {
+    it("should successfully initialize a chat session", async () => {
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+
+      expect(responseData).toEqual({
+        id: TEST_DATA.SESSION_ID,
+        key: TEST_DATA.SESSION_KEY,
+        affinityToken: TEST_DATA.AFFINITY_TOKEN,
+      });
+
+      expect(response.headers.get(HANDOFF_AUTH_HEADER)).toBe(
+        TEST_DATA.JWT_TOKEN,
+      );
+    });
+
+    it("should return 400 when user data is missing", async () => {
+      const response = await POST({
+        json: vi.fn().mockResolvedValue({
+          messages: [TEST_DATA.DEFAULT_MESSAGE],
+          unsignedUserData: null,
+        }),
+      } as unknown as NextRequest);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "Missing user data",
+      });
+    });
+
+    it("should handle session initialization failure", async () => {
+      global.fetch = vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+        }),
+      );
+
+      const response = await POST(
+        createMockRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("Message Handling", () => {
+    it("should send initial messages after session creation", async () => {
+      await POST(createMockRequest() as unknown as NextRequest);
+
+      expect(sendChatMessage).toHaveBeenCalled();
+      expect(vi.mocked(sendChatMessage).mock.calls[0][0]).toContain(
+        "MAVEN TRANSCRIPT HISTORY",
+      );
+    });
+  });
+});

--- a/__tests__/app/api/salesforce/messages/route.test.ts
+++ b/__tests__/app/api/salesforce/messages/route.test.ts
@@ -1,0 +1,137 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { GET, POST } from "@/app/api/salesforce/messages/route";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  sendChatMessage,
+  validateSalesforceConfig,
+} from "@/app/api/salesforce/utils";
+
+// Mock external dependencies
+vi.mock("@/app/api/server/utils", () => ({
+  withSettingsAndAuthentication: vi.fn((req, handler) =>
+    handler(
+      req,
+      {
+        handoffConfiguration: {
+          type: "salesforce",
+          chatHostUrl: "https://test.salesforce.com",
+          apiSecret: "test-secret",
+        },
+      },
+      "test-org-id",
+      "test-agent-id",
+      "test-user-id",
+      "test-conversation-id",
+      {
+        affinityToken: "test-affinity-token",
+        sessionKey: "test-session-key",
+      },
+    ),
+  ),
+}));
+
+vi.mock("@/app/api/salesforce/utils", async () => {
+  const actual = await vi.importActual("@/app/api/salesforce/utils");
+  return {
+    ...(actual as object),
+    validateSalesforceConfig: vi.fn(),
+    validateAuthHeaders: vi.fn(),
+    sendChatMessage: vi.fn(),
+  };
+});
+
+describe("Salesforce Messages API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  describe("GET /api/salesforce/messages", () => {
+    const createGetRequest = (headers: Record<string, string> = {}) => ({
+      signal: { aborted: false },
+      headers: {
+        get: vi.fn((key: string) => headers[key]),
+      },
+    });
+
+    it("should stream messages successfully", async () => {
+      const messages = [
+        {
+          type: "ChatMessage",
+          message: { text: "Hello" },
+        },
+      ];
+
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ messages, sequence: 1, offset: 0 }),
+      } as unknown as Response);
+
+      const response = await GET(createGetRequest() as unknown as NextRequest);
+      const reader = response.body?.getReader();
+      const { value } = (await reader?.read()) || {};
+      const text = new TextDecoder().decode(value);
+
+      expect(response.status).toBe(200);
+      expect(text).toContain("Hello");
+    });
+
+    it("should handle empty message responses", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        status: 204,
+      } as Response);
+
+      const response = await GET(createGetRequest() as unknown as NextRequest);
+      const reader = response.body?.getReader();
+      const { done } = (await reader?.read()) || {};
+
+      expect(response.status).toBe(200);
+      expect(done).toBe(true);
+    });
+  });
+
+  describe("POST /api/salesforce/messages", () => {
+    const createPostRequest = (message = "Test message") => ({
+      json: vi.fn().mockResolvedValue({ message }),
+    });
+
+    it("should send message successfully", async () => {
+      const response = await POST(
+        createPostRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toBe("Chat message sent");
+    });
+
+    it("should handle send message failure", async () => {
+      vi.mocked(sendChatMessage).mockRejectedValueOnce(
+        new Error("Failed to send"),
+      );
+
+      const response = await POST(
+        createPostRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toBe("Failed to send chat message");
+    });
+
+    it("should validate configuration", async () => {
+      vi.mocked(validateSalesforceConfig).mockReturnValueOnce(
+        new NextResponse(JSON.stringify({ error: "Invalid configuration" }), {
+          status: 400,
+        }),
+      );
+
+      const response = await POST(
+        createPostRequest() as unknown as NextRequest,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "Invalid configuration",
+      });
+    });
+  });
+});

--- a/__tests__/packages/components/chat/use-chat.test.tsx
+++ b/__tests__/packages/components/chat/use-chat.test.tsx
@@ -4,6 +4,7 @@ import { useChat } from "@/packages/components/chat/use-chat";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { useParams } from "next/navigation";
 import { ChatMessage } from "@/types";
+import { NextResponse } from "next/server";
 
 // Mock dependencies
 vi.mock("next/navigation", () => ({
@@ -36,6 +37,22 @@ describe("useChat", () => {
     (useAuth as any).mockReturnValue({
       signedUserData: "test-signed-data",
     });
+
+    // Enhanced mock with stream and response.ok
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    (global.fetch as any).mockResolvedValue(
+      new NextResponse(mockStream, {
+        headers: {
+          "X-Maven-Auth-Token": "mock-token",
+        },
+        status: 200,
+      }),
+    );
   });
 
   it("should initialize with empty messages", () => {

--- a/app/api/front/webhook/[organizationId]/[agentId]/route.ts
+++ b/app/api/front/webhook/[organizationId]/[agentId]/route.ts
@@ -130,10 +130,13 @@ export const DELETE = async (
   }
 
   // TODO: track this event in amplitude?
-  console.log(`Received ${request.method} ${request.url} request`, {
-    orgId,
-    agentId,
-  });
+  if (process.env.ENABLE_API_LOGGING) {
+    console.log(`Received ${request.method} ${request.url} request`, {
+      orgId,
+      agentId,
+    });
+  }
+
   return NextResponse.json(
     {
       type: "success",

--- a/app/api/salesforce/conversations/passControl/route.ts
+++ b/app/api/salesforce/conversations/passControl/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
 
         return NextResponse.json({ success: true });
       } catch (error) {
-        console.log("endChatSession failed:", error);
+        console.error("endChatSession failed:", error);
         return NextResponse.json(
           { error: "Internal Server Error" },
           { status: 500 },

--- a/app/api/salesforce/conversations/passControl/route.ts
+++ b/app/api/salesforce/conversations/passControl/route.ts
@@ -1,0 +1,59 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withSettingsAndAuthentication } from "@/app/api/server/utils";
+import {
+  generateSessionInitRequestHeaders,
+  validateSalesforceConfig,
+  validateAuthHeaders,
+} from "@/app/api/salesforce/utils";
+
+export async function POST(req: NextRequest) {
+  return withSettingsAndAuthentication(
+    req,
+    async (
+      _req,
+      settings,
+      _orgId,
+      _agentId,
+      _userId,
+      _conversationId,
+      authPayload,
+    ) => {
+      const { handoffConfiguration } = settings;
+      const validationError = validateSalesforceConfig(handoffConfiguration);
+      if (validationError) return validationError;
+
+      const { affinityToken, sessionKey } = authPayload;
+      const { chatHostUrl: url } =
+        handoffConfiguration as SalesforceHandoffConfiguration;
+
+      const authError = validateAuthHeaders(affinityToken, sessionKey);
+      if (authError) return authError;
+
+      try {
+        const chatSessionEndResponse = await fetch(
+          url + `/chat/rest/System/SessionId/${sessionKey || ""}`,
+          {
+            method: "DELETE",
+            headers: generateSessionInitRequestHeaders(
+              sessionKey as string,
+              affinityToken as string,
+            ),
+          },
+        );
+
+        if (!chatSessionEndResponse.ok) {
+          console.log("Failed to end chat session", chatSessionEndResponse);
+          throw new Error("Failed to end chat session");
+        }
+
+        return NextResponse.json({ success: true });
+      } catch (error) {
+        console.log("endChatSession failed:", error);
+        return NextResponse.json(
+          { error: "Internal Server Error" },
+          { status: 500 },
+        );
+      }
+    },
+  );
+}

--- a/app/api/salesforce/conversations/route.ts
+++ b/app/api/salesforce/conversations/route.ts
@@ -127,7 +127,7 @@ export async function POST(req: NextRequest) {
         },
       );
     } catch (error) {
-      console.log("initiateChatSession failed:", error);
+      console.error("initiateChatSession failed:", error);
       return NextResponse.json(
         { error: "Internal Server Error" },
         { status: 500 },

--- a/app/api/salesforce/conversations/route.ts
+++ b/app/api/salesforce/conversations/route.ts
@@ -1,0 +1,139 @@
+import { type NextRequest, NextResponse } from "next/server";
+import jwt from "jsonwebtoken";
+import { sendChatMessage } from "@/app/api/salesforce/utils";
+import { withAppSettings } from "@/app/api/server/utils";
+import type {
+  ChatSessionResponse,
+  SalesforceRequest,
+} from "@/types/salesforce";
+import {
+  generateSessionInitRequestBody,
+  generateSessionInitRequestHeaders,
+  convertMessagesToTranscriptText,
+  SESSION_CREDENTIALS_REQUEST_HEADERS,
+} from "@/app/api/salesforce/utils";
+import { HANDOFF_AUTH_HEADER } from "@/app/constants/authentication";
+
+// initializing salesforce chat session
+export async function POST(req: NextRequest) {
+  return withAppSettings(req, async (req, settings) => {
+    const { handoffConfiguration } = settings;
+    if (handoffConfiguration?.type !== "salesforce") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Invalid handoff configuration type. Expected 'salesforce'.",
+        },
+        { status: 400 },
+      );
+    }
+    const {
+      chatHostUrl,
+      chatButtonId,
+      deploymentId,
+      orgId,
+      eswLiveAgentDevName,
+    } = handoffConfiguration;
+
+    const {
+      unsignedUserData: userData,
+      messages,
+      userAgent,
+      screenResolution,
+      language,
+      customData,
+    } = (await req.json()) as SalesforceRequest;
+    if (!userData) {
+      return NextResponse.json({ error: "Missing user data" }, { status: 400 });
+    }
+
+    try {
+      const chatSessionCredentialsResponse = await fetch(
+        chatHostUrl + "/chat/rest/System/SessionId",
+        {
+          method: "GET",
+          headers: SESSION_CREDENTIALS_REQUEST_HEADERS,
+        },
+      );
+
+      if (!chatSessionCredentialsResponse.ok) {
+        console.log(
+          "Failed to initiate chat session",
+          chatSessionCredentialsResponse,
+        );
+        throw new Error("Failed to initiate chat session");
+      }
+
+      const chatSessionCredentials: ChatSessionResponse =
+        await chatSessionCredentialsResponse.json();
+
+      const requestBody = generateSessionInitRequestBody(
+        chatSessionCredentials,
+        { ...userData, userAgent, screenResolution, language },
+        orgId,
+        deploymentId,
+        customData?.buttonId || chatButtonId,
+        customData?.eswLiveAgentDevName || eswLiveAgentDevName,
+        chatSessionCredentials.key,
+      );
+
+      const chatSessionInitResponse = await fetch(
+        chatHostUrl + "/chat/rest/Chasitor/ChasitorInit",
+        {
+          method: "POST",
+          headers: generateSessionInitRequestHeaders(
+            chatSessionCredentials.key,
+            chatSessionCredentials.affinityToken,
+          ),
+          body: JSON.stringify(requestBody),
+        },
+      );
+
+      if (!chatSessionInitResponse.ok) {
+        console.log("Failed to initiate chat session", chatSessionInitResponse);
+        throw new Error("Failed to initiate chat session");
+      }
+
+      // Send messages
+      await sendChatMessage(
+        convertMessagesToTranscriptText(messages),
+        chatSessionCredentials.affinityToken,
+        chatSessionCredentials.key,
+        chatHostUrl,
+      );
+
+      const token = jwt.sign(
+        {
+          scope: "appUser",
+          sessionId: chatSessionCredentials.id,
+          sessionKey: chatSessionCredentials.key,
+          affinityToken: chatSessionCredentials.affinityToken,
+          isAuthenticated: false,
+        },
+        handoffConfiguration.apiSecret,
+        {
+          keyid: orgId,
+        },
+      );
+
+      return NextResponse.json(
+        {
+          ...chatSessionCredentials,
+        },
+        {
+          headers: {
+            [HANDOFF_AUTH_HEADER]: token,
+          },
+        },
+      );
+    } catch (error) {
+      console.log("initiateChatSession failed:", error);
+      return NextResponse.json(
+        { error: "Internal Server Error" },
+        { status: 500 },
+      );
+    }
+  });
+}
+
+export const maxDuration = 300;

--- a/app/api/salesforce/conversations/route.ts
+++ b/app/api/salesforce/conversations/route.ts
@@ -90,7 +90,7 @@ export async function POST(req: NextRequest) {
       );
 
       if (!chatSessionInitResponse.ok) {
-        console.log("Failed to initiate chat session", chatSessionInitResponse);
+        console.error("Failed to initiate chat session", chatSessionInitResponse);
         throw new Error("Failed to initiate chat session");
       }
 

--- a/app/api/salesforce/messages/route.ts
+++ b/app/api/salesforce/messages/route.ts
@@ -1,0 +1,198 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  type ChatMessageResponse,
+  type SalesforceChatMessage,
+  SALESFORCE_CHAT_SUBJECT_HEADER_KEY,
+} from "@/types/salesforce";
+
+import {
+  SALESFORCE_ALLOWED_MESSAGE_TYPES,
+  SALESFORCE_API_BASE_HEADERS,
+  SALESFORCE_CHAT_PROMPT_MESSAGE_NAMES,
+  SALESFORCE_CHAT_PROMPT_MESSAGE_TEXTS,
+  sendChatMessage,
+  validateSalesforceConfig,
+  validateAuthHeaders,
+} from "@/app/api/salesforce/utils";
+import { withSettingsAndAuthentication } from "../../server/utils";
+
+async function fetchChatMessages(
+  url: string,
+  ack: number,
+  affinityToken: string,
+  sessionKey: string,
+): Promise<ChatMessageResponse> {
+  const response = await fetch(`${url}/chat/rest/System/Messages?ack=${ack}`, {
+    method: "GET",
+    headers: {
+      ...SALESFORCE_API_BASE_HEADERS,
+      "X-LIVEAGENT-AFFINITY": affinityToken,
+      "X-LIVEAGENT-SESSION-KEY": sessionKey,
+    },
+  });
+
+  if (response.status === 204) {
+    return {
+      messages: [],
+      sequence: ack,
+      offset: 0,
+    };
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to get chat messages");
+  }
+
+  return response.json();
+}
+
+function filterMessages(messages: SalesforceChatMessage[]) {
+  return messages.filter((message) =>
+    SALESFORCE_ALLOWED_MESSAGE_TYPES.includes(message.type),
+  );
+}
+
+function isSubjectPromptMessage(message: SalesforceChatMessage) {
+  return (
+    SALESFORCE_CHAT_PROMPT_MESSAGE_NAMES.includes(message.message.name || "") &&
+    SALESFORCE_CHAT_PROMPT_MESSAGE_TEXTS.includes(message.message.text || "")
+  );
+}
+
+async function handleMessageStreaming(
+  req: NextRequest,
+  url: string,
+  affinityToken: string,
+  sessionKey: string,
+) {
+  const stream = new ReadableStream({
+    async start(controller) {
+      let ack = -1;
+      try {
+        while (!req.signal.aborted) {
+          const { sequence, messages } = await fetchChatMessages(
+            url,
+            ack,
+            affinityToken,
+            sessionKey,
+          );
+          const filteredMessages = filterMessages(messages);
+          ack = sequence;
+
+          for (const message of filteredMessages) {
+            if (isSubjectPromptMessage(message)) {
+              void sendChatMessage(
+                req.headers.get(SALESFORCE_CHAT_SUBJECT_HEADER_KEY) ||
+                  "I need assistance",
+                affinityToken,
+                sessionKey,
+                url,
+              );
+              continue;
+            }
+
+            controller.enqueue(
+              new TextEncoder().encode(
+                `data: ${JSON.stringify({
+                  message: message as SalesforceChatMessage,
+                })}\n\n`,
+              ),
+            );
+          }
+        }
+      } catch (error) {
+        console.log("Failed to get chat messages:", error);
+      } finally {
+        controller.close();
+      }
+    },
+    cancel() {
+      console.log("Stream cancelled by client");
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+export async function GET(req: NextRequest) {
+  return withSettingsAndAuthentication(
+    req,
+    async (
+      req,
+      settings,
+      _orgId,
+      _agentId,
+      _userId,
+      _conversationId,
+      authPayload,
+    ) => {
+      const { handoffConfiguration } = settings;
+      const validationError = validateSalesforceConfig(handoffConfiguration);
+      if (validationError) return validationError;
+
+      const { affinityToken, sessionKey } = authPayload;
+      const { chatHostUrl: url } =
+        handoffConfiguration as SalesforceHandoffConfiguration;
+
+      const authError = validateAuthHeaders(affinityToken, sessionKey);
+      if (authError) return authError;
+
+      return handleMessageStreaming(
+        req,
+        url,
+        affinityToken as string,
+        sessionKey as string,
+      );
+    },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  return withSettingsAndAuthentication(
+    req,
+    async (
+      req,
+      settings,
+      _orgId,
+      _agentId,
+      _userId,
+      _conversationId,
+      authPayload,
+    ) => {
+      const { handoffConfiguration } = settings;
+      const validationError = validateSalesforceConfig(handoffConfiguration);
+      if (validationError) return validationError;
+
+      const {
+        message,
+      }: {
+        message: string;
+        signedUserData: string | null;
+        unsignedUserData: Record<string, any> | null;
+      } = await req.json();
+      const { chatHostUrl: url } =
+        handoffConfiguration as SalesforceHandoffConfiguration;
+      const { affinityToken, sessionKey } = authPayload;
+
+      const authError = validateAuthHeaders(affinityToken, sessionKey);
+      if (authError) return authError;
+
+      try {
+        await sendChatMessage(
+          message,
+          affinityToken as string,
+          sessionKey as string,
+          url as string,
+        );
+        return Response.json("Chat message sent");
+      } catch (error) {
+        console.log("Failed to send chat message:", error);
+        return Response.json("Failed to send chat message", { status: 500 });
+      }
+    },
+  );
+}
+
+export const maxDuration = 300;

--- a/app/api/salesforce/utils.ts
+++ b/app/api/salesforce/utils.ts
@@ -1,0 +1,230 @@
+import { NextResponse } from "next/server";
+import type { Message } from "@/types";
+import type {
+  ChatSessionResponse,
+  EntityFieldMap,
+  SalesforceChatUserData,
+  PrechatDetail,
+} from "@/types/salesforce";
+
+export const SALESFORCE_CHAT_PROMPT_MESSAGE_NAMES = [
+  "Management Center",
+  "Management Center with Maven",
+];
+export const SALESFORCE_CHAT_PROMPT_MESSAGE_TEXTS = [
+  "Please enter the subject",
+];
+
+export const SALESFORCE_ALLOWED_MESSAGE_TYPES = [
+  // 'ChatRequestSuccess',
+  // 'ChatEstablished',
+  // 'TransferToButtonInitiated',
+  // 'ChatEstablished',
+  "ChatTransferred",
+  "QueueUpdate",
+  "AgentTyping",
+  "AgentNotTyping",
+  "ChatMessage",
+  "ChatEnded",
+];
+export const SALESFORCE_API_BASE_HEADERS = {
+  "X-LIVEAGENT-API-VERSION": "34",
+  "Access-Control-Allow-Origin": "*",
+};
+
+export function validateSalesforceConfig(handoffConfiguration: any) {
+  if (handoffConfiguration?.type !== "salesforce") {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Invalid handoff configuration type. Expected 'salesforce'.",
+      },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
+export function validateAuthHeaders(
+  affinityToken: string | undefined,
+  sessionKey: string | undefined,
+) {
+  if (!affinityToken || !sessionKey) {
+    return Response.json("Missing auth headers", {
+      status: 401,
+    });
+  }
+  return null;
+}
+
+export async function sendChatMessage(
+  text: string,
+  affinityToken: string,
+  sessionKey: string,
+  url: string,
+) {
+  const body = JSON.stringify({
+    text,
+  });
+
+  try {
+    const response = await fetch(url + "/chat/rest/Chasitor/ChatMessage", {
+      method: "POST",
+      headers: {
+        ...SALESFORCE_API_BASE_HEADERS,
+        "X-LIVEAGENT-AFFINITY": affinityToken,
+        "X-LIVEAGENT-SESSION-KEY": sessionKey,
+        "Content-Type": "application/json",
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      console.error("Failed to send chat message", response);
+      throw new Error("Failed to send chat message");
+    }
+
+    return response;
+  } catch (error) {
+    console.error("Failed to send chat message:", error);
+    throw error;
+  }
+}
+
+export const SESSION_CREDENTIALS_REQUEST_HEADERS = {
+  "X-LIVEAGENT-API-VERSION": "34",
+  "X-LIVEAGENT-AFFINITY": "",
+  "Access-Control-Allow-Origin": "*",
+};
+
+export const SESSION_INIT_REQUEST_HEADERS = {
+  ...SESSION_CREDENTIALS_REQUEST_HEADERS,
+  "Content-Type": "application/json",
+  "X-LIVEAGENT-SEQUENCE": "1",
+};
+
+export const generateSessionInitRequestHeaders = (
+  key: string,
+  affinityToken: string,
+) => ({
+  ...SESSION_INIT_REQUEST_HEADERS,
+  "X-LIVEAGENT-SESSION-KEY": key,
+  "X-LIVEAGENT-AFFINITY": affinityToken,
+});
+
+export const convertMessagesToTranscriptText = (
+  messages: Message[],
+): string => {
+  let transcriptText = "MAVEN TRANSCRIPT HISTORY\n\n";
+  messages.forEach((message) => {
+    if (message.type === "USER") {
+      transcriptText += `Visitor: ${message.text}\n\n`;
+    } else if (message.type === "bot") {
+      transcriptText += `Maven bot: ${message.responses.map((r: any) => r.text.replaceAll("\\n", "\n")).join("")}\n\n`;
+    }
+  });
+
+  return transcriptText.trim();
+};
+
+const createPrechatDetail = (
+  label: string,
+  value: string | boolean,
+  displayToAgent: boolean,
+  transcriptFields: string[] = [],
+): PrechatDetail => ({
+  label,
+  value,
+  entityMaps: [],
+  displayToAgent,
+  doKnowledgeSearch: false,
+  transcriptFields,
+});
+
+const createEntityFieldMap = (
+  fieldName: string,
+  label: string,
+): EntityFieldMap => ({
+  fieldName,
+  label,
+  doFind: true,
+  isExactMatch: true,
+  doCreate: false,
+});
+
+export const generateSessionInitRequestBody = (
+  chatSessionCredentials: ChatSessionResponse,
+  userData: SalesforceChatUserData,
+  organizationId: string,
+  deploymentId: string,
+  buttonId: string,
+  eswLiveAgentDevName: string,
+  sessionKey: string,
+) => {
+  const visibleFields = [
+    ["First Name", userData.firstName, "First_Name__c"],
+    ["Last Name", userData.lastName, "Last_Name__c"],
+    ["Email", userData.email, "Email__c"],
+    ["Location Id", userData.locationId, "Location_Id__c"],
+  ];
+
+  const hiddenFields: [string, string | boolean, string][] = [
+    ["Session Id", sessionKey, "Session_Id__c"],
+    ["User Id", userData.userId, "User_Id__c"],
+    ["Location Type", userData.locationType, "Location_Type__c"],
+    ["Origin", "Chat", ""],
+    ["eswLiveAgentDevName", eswLiveAgentDevName, ""],
+    ["hasOnlyExtraPrechatInfo", false, ""],
+  ];
+
+  const prechatDetails = [
+    ...visibleFields.map(([label, value, field]) =>
+      createPrechatDetail(label, value as string, true, field ? [field] : []),
+    ),
+    ...hiddenFields.map(([label, value, field]) =>
+      createPrechatDetail(label, value, false, field ? [field] : []),
+    ),
+  ];
+
+  const entityFieldsMaps = [
+    createEntityFieldMap("FirstName", "First Name"),
+    createEntityFieldMap("LastName", "Last Name"),
+    createEntityFieldMap("Email", "Email"),
+  ];
+
+  return {
+    organizationId,
+    deploymentId,
+    buttonId,
+    sessionId: chatSessionCredentials.id,
+    trackingId: "",
+    userAgent: userData.userAgent,
+    language: userData.language,
+    screenResolution: userData.screenResolution,
+    visitorName: userData.firstName,
+    prechatDetails,
+    buttonOverrides: [],
+    receiveQueueUpdates: true,
+    isPost: false,
+    prechatEntities: [
+      {
+        entityName: "Contact",
+        showOnCreate: true,
+        linkToEntityName: "",
+        linkToEntityField: "ContactId",
+        saveToTranscript: "ContactId",
+        entityFieldsMaps,
+      },
+    ],
+    visitorInfo: {
+      visitCount: 1,
+      originalReferrer: "https://www.tripadvisor.com/",
+      pages: [
+        {
+          location: "https://www.jscache.com/static/t4b/support_chat.html",
+          time: Date.now(),
+        },
+      ],
+    },
+  };
+};

--- a/app/api/server/utils.ts
+++ b/app/api/server/utils.ts
@@ -176,6 +176,7 @@ export type RouteHandlerWithAuth<T> = (
   agentId: string,
   userId: string,
   conversationId: string,
+  authPayload: AuthJWTPayload,
 ) => Promise<T>;
 
 export async function withApiAuthentication<T>(
@@ -197,13 +198,14 @@ export async function withApiAuthentication<T>(
 
   let userId: string;
   let conversationId: string;
-
+  let authPayload: AuthJWTPayload;
   try {
     const encoder = new TextEncoder();
     const secret = encoder.encode(settings.handoffConfiguration.apiSecret);
     const { payload } = await jwtVerify(apiToken, secret);
     userId = payload.userId as string;
     conversationId = payload.conversationId as string;
+    authPayload = payload;
   } catch (error) {
     throw new Error("Invalid API token", { cause: error });
   }
@@ -215,6 +217,7 @@ export async function withApiAuthentication<T>(
     agentId,
     userId,
     conversationId,
+    authPayload,
   );
 }
 
@@ -225,6 +228,7 @@ export type RouteHandlerWithSettingsAndAuth<T> = (
   agentId: string,
   userId: string,
   conversationId: string,
+  authPayload: AuthJWTPayload,
 ) => Promise<T>;
 
 export async function withSettingsAndAuthentication<T>(
@@ -246,6 +250,7 @@ export async function withSettingsAndAuthentication<T>(
           agentId,
           userId,
           conversationId,
+          authPayload,
         ) => {
           return handler(
             req,
@@ -254,6 +259,7 @@ export async function withSettingsAndAuthentication<T>(
             agentId,
             userId,
             conversationId,
+            authPayload,
           );
         },
       );

--- a/app/constants/authentication.ts
+++ b/app/constants/authentication.ts
@@ -2,15 +2,13 @@ import { type JWTPayload } from "jose";
 
 export const AUTHENTICATION_HEADER = "X-Maven-Auth-Token";
 export interface AuthJWTPayload extends JWTPayload {
-  userId: string;
-  conversationId: string;
+  userId?: string;
+  conversationId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  affinityToken?: string;
 }
 
 export const HANDOFF_AUTH_HEADER = "X-Handoff-Auth-Token";
 export const ORGANIZATION_HEADER = "X-Organization-Id";
 export const AGENT_HEADER = "X-Agent-Id";
-
-export interface HandoffJWTPayload extends JWTPayload {
-  userId: string;
-  conversationId: string;
-}


### PR DESCRIPTION
# Salesforce Handoff API Integration

This PR adds API endpoints to support handoff functionality to Salesforce Live Agent chat, enabling transition from Maven bot to live Salesforce agents.

## Key Changes

### New API Endpoints

- `/api/salesforce/conversations` - Handles chat session initialization and setup
- `/api/salesforce/conversations/passControl` - Manages chat session termination
- `/api/salesforce/messages` - Handles bi-directional message streaming between Maven and Salesforce

### Core Features

- **Chat Session Management**: Full lifecycle support for Salesforce chat sessions including initialization, message handling, and termination
- **Real-time Message Streaming**: Server-sent events implementation for real-time message delivery
- **Transcript History**: Automatic transfer of Maven chat history to Salesforce agents
- **Authentication**: JWT-based authentication for secure handoff communication
- **Configuration Validation**: Robust validation of Salesforce configuration settings

### Implementation Details

- Test coverage for all new endpoints
- Error handling for network issues and invalid configurations
- Support for custom fields and prechat details in Salesforce
- Proper cleanup of resources and session management (stream cancellation and handoff passcontrol)
