### PR TITLE
feat: conditionally send transcript in sf chat handoff

### DIFF
--- a/app/api/salesforce/conversations/route.ts
+++ b/app/api/salesforce/conversations/route.ts
@@ -1,9 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
 import jwt from "jsonwebtoken";
-import { sendChatMessage } from "@/app/api/salesforce/utils";
+import { fetchChatMessages, sendChatMessage } from "@/app/api/salesforce/utils";
 import { withAppSettings } from "@/app/api/server/utils";
 import type {
   ChatSessionResponse,
+  SalesforceChatMessage,
   SalesforceRequest,
 } from "@/types/salesforce";
 import {
@@ -13,6 +14,13 @@ import {
   SESSION_CREDENTIALS_REQUEST_HEADERS,
 } from "@/app/api/salesforce/utils";
 import { HANDOFF_AUTH_HEADER } from "@/app/constants/authentication";
+
+function containsChatRequestSuccess(messages: SalesforceChatMessage[]) {
+  return messages.some(
+    // TODO: Replace hardcoded message name
+    (message) => message.type === "ChatRequestSuccess",
+  );
+}
 
 // initializing salesforce chat session
 export async function POST(req: NextRequest) {
@@ -101,13 +109,23 @@ export async function POST(req: NextRequest) {
         throw new Error("Failed to initiate chat session");
       }
 
-      // Send messages
-      await sendChatMessage(
-        convertMessagesToTranscriptText(messages),
+      // Check for the presence of the "ChatRequestSuccess" message
+      const initialChatMessages = await fetchChatMessages(
+        chatHostUrl,
+        -1,
         chatSessionCredentials.affinityToken,
         chatSessionCredentials.key,
-        chatHostUrl,
       );
+
+      if (containsChatRequestSuccess(initialChatMessages.messages)) {
+        // Send messages
+        await sendChatMessage(
+          convertMessagesToTranscriptText(messages),
+          chatSessionCredentials.affinityToken,
+          chatSessionCredentials.key,
+          chatHostUrl,
+        );
+      }
 
       const token = jwt.sign(
         {

--- a/app/api/salesforce/messages/route.ts
+++ b/app/api/salesforce/messages/route.ts
@@ -1,56 +1,19 @@
 import { type NextRequest, NextResponse } from "next/server";
 import {
-  type ChatMessageResponse,
   type SalesforceChatMessage,
   SALESFORCE_CHAT_SUBJECT_HEADER_KEY,
 } from "@/types/salesforce";
 
 import {
   SALESFORCE_ALLOWED_MESSAGE_TYPES,
-  SALESFORCE_API_BASE_HEADERS,
   SALESFORCE_CHAT_PROMPT_MESSAGE_NAMES,
   SALESFORCE_CHAT_PROMPT_MESSAGE_TEXTS,
   sendChatMessage,
   validateSalesforceConfig,
   validateAuthHeaders,
+  fetchChatMessages,
 } from "@/app/api/salesforce/utils";
 import { withSettingsAndAuthentication } from "../../server/utils";
-
-async function fetchChatMessages(
-  url: string,
-  ack: number,
-  affinityToken: string,
-  sessionKey: string,
-): Promise<ChatMessageResponse> {
-  const response = await fetch(`${url}/chat/rest/System/Messages?ack=${ack}`, {
-    method: "GET",
-    headers: {
-      ...SALESFORCE_API_BASE_HEADERS,
-      "X-LIVEAGENT-AFFINITY": affinityToken,
-      "X-LIVEAGENT-SESSION-KEY": sessionKey,
-    },
-  });
-
-  if (response.status === 204) {
-    return {
-      messages: [],
-      sequence: ack,
-      offset: 0,
-    };
-  }
-
-  if (!response.ok) {
-    throw new Error("Failed to get chat messages");
-  }
-
-  const data = await response.json();
-
-  if (process.env.ENABLE_API_LOGGING) {
-    console.log("GET MESSAGES RESPONSE", JSON.stringify(data, null, 2));
-  }
-
-  return data;
-}
 
 function filterMessages(messages: SalesforceChatMessage[]) {
   return messages.filter((message) =>

--- a/app/api/salesforce/utils.ts
+++ b/app/api/salesforce/utils.ts
@@ -5,6 +5,7 @@ import type {
   EntityFieldMap,
   SalesforceChatUserData,
   PrechatDetail,
+  ChatMessageResponse,
 } from "@/types/salesforce";
 
 export const SALESFORCE_CHAT_PROMPT_MESSAGE_NAMES = [
@@ -228,3 +229,39 @@ export const generateSessionInitRequestBody = (
     },
   };
 };
+
+export async function fetchChatMessages(
+  url: string,
+  ack: number,
+  affinityToken: string,
+  sessionKey: string,
+): Promise<ChatMessageResponse> {
+  const response = await fetch(`${url}/chat/rest/System/Messages?ack=${ack}`, {
+    method: "GET",
+    headers: {
+      ...SALESFORCE_API_BASE_HEADERS,
+      "X-LIVEAGENT-AFFINITY": affinityToken,
+      "X-LIVEAGENT-SESSION-KEY": sessionKey,
+    },
+  });
+
+  if (response.status === 204) {
+    return {
+      messages: [],
+      sequence: ack,
+      offset: 0,
+    };
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to get chat messages");
+  }
+
+  const data = await response.json();
+
+  if (process.env.ENABLE_API_LOGGING) {
+    console.log("GET MESSAGES RESPONSE", JSON.stringify(data, null, 2));
+  }
+
+  return data;
+}


### PR DESCRIPTION
# Description

Adds conditional transcript delivery based on Salesforce chat session initialization status.

# Changes

- Added check for ChatRequestSuccess message before sending initial messages
- Moved fetchChatMessages function to utils for reusability

# Testing

- Added tests for ChatRequestSuccess message handling
- Updated existing conversation tests
- All tests passing
