### PR TITLE
Add front rate-limiting

### DIFF
--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -56,7 +56,7 @@ function createRetryRateLimiter(minTime: number) {
         error.response.headers.get("retry-after")!,
         10,
       );
-      return retryAfterSeconds;
+      return retryAfterSeconds * 1000;
     }
     return defaultRetryAfter;
   });

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -5,21 +5,21 @@ import { jsonFetch, JsonFetchError } from "@/lib/jsonFetch";
 import Bottleneck from "bottleneck";
 
 export enum RetryableStatusCodes {
-  TooManyRequests = 429,
-  InternalServerError = 500,
-  NotImplemented = 501,
-  BadGateway = 502,
-  ServiceUnavailable = 503,
-  GatewayTimeout = 504,
+  TOO_MANY_REQUESTS = 429,
+  INTERNAL_SERVER_ERROR = 500,
+  NOT_IMPLEMENTED = 501,
+  BAD_GATEWAY = 502,
+  SERVICE_UNAVAILABLE = 503,
+  GATEWAY_TIMEOUT = 504,
 }
 
 export const DEFAULT_API_HOST = "https://api2.frontapp.com";
 
 // https://dev.frontapp.com/docs/rate-limiting#standard-rate-limits
 export enum StandardRateLimits {
-  Starter = 1200,
-  Growth = 600,
-  Scale = 300,
+  STARTER = 1200,
+  GROWTH = 600,
+  SCALE = 300,
 }
 
 function createRetryRateLimiter(minTime: number) {
@@ -70,7 +70,7 @@ export class FrontCoreClient {
     private apiKey: string,
     private host: string = DEFAULT_API_HOST,
 
-    private standardRateLimit: StandardRateLimits = StandardRateLimits.Starter,
+    private standardRateLimit: StandardRateLimits = StandardRateLimits.STARTER,
   ) {
     this.standardRateLimiter = createRetryRateLimiter(this.standardRateLimit);
     // 5 requests per second per conversation, https://dev.frontapp.com/docs/rate-limiting#additional-burst-rate-limiting

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -27,17 +27,19 @@ function createRetryRateLimiter(minTime: number) {
     minTime: minTime,
   });
   limiter.on("failed", async (error, info) => {
-    console.error("FRONT:: API Request failed", {
-      attempt: info.retryCount,
-      message: error.message,
-      ...(error instanceof JsonFetchError
-        ? {
-            status: error.response.status,
-            statusText: error.response.statusText,
-            response: await error.response.text(),
-          }
-        : {}),
-    });
+    if (process.env.ENABLE_API_LOGGING) {
+      console.error("FRONT:: API Request failed", {
+        attempt: info.retryCount,
+        message: error.message,
+        ...(error instanceof JsonFetchError
+          ? {
+              status: error.response.status,
+              statusText: error.response.statusText,
+              response: await error.response.text(),
+            }
+          : {}),
+      });
+    }
     const { retryCount } = info;
     const backoffs = [0.2, 0.4, 0.8, 1, 2];
     if (backoffs.length <= retryCount) {

--- a/lib/jsonFetch.ts
+++ b/lib/jsonFetch.ts
@@ -9,9 +9,10 @@ export class JsonFetchError extends Error {
 
 export async function jsonFetch<T = any>(
   url: string | URL,
-  { method = "GET", body, headers, ...rest }: RequestInit,
+  init?: RequestInit,
 ) {
-  const init: RequestInit = {
+  const { method = "GET", body, headers, ...rest } = init ?? {};
+  const requestInit: RequestInit = {
     method,
     headers: {
       ...(headers instanceof Headers
@@ -24,9 +25,9 @@ export async function jsonFetch<T = any>(
     ...rest,
   };
   if (body) {
-    init.body = body;
+    requestInit.body = body;
   }
-  const response = await fetch(url, init);
+  const response = await fetch(url, requestInit);
   if (!response.ok) {
     // throw an error and provide the response so the caller handle
     throw new JsonFetchError(


### PR DESCRIPTION
I already have this in the front repo to handle message syncing failures for ticket creation and its working well... I need to bring this over here too.

The implements rate-limiting and retries following Front's guidelines