### PR TITLE
APP-245: refactor retry logic for FrontApplicationClient

### DIFF
--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -5,6 +5,7 @@ import { jsonFetch, JsonFetchError } from "@/lib/jsonFetch";
 import Bottleneck from "bottleneck";
 
 export enum RetryableStatusCodes {
+  UNAUTHORIZED = 401,
   TOO_MANY_REQUESTS = 429,
   INTERNAL_SERVER_ERROR = 500,
   NOT_IMPLEMENTED = 501,

--- a/app/api/front/client.ts
+++ b/app/api/front/client.ts
@@ -157,12 +157,31 @@ export class FrontApplicationClient {
   private tokenDuration: number = 30; // seconds
   private token?: string;
   private tokenTimeout?: NodeJS.Timeout;
+  burstRateLimiter: Bottleneck;
   constructor(
     private appId: string,
     private appSecret: string,
     private channelId: string,
     private host: string = DEFAULT_API_HOST,
-  ) {}
+  ) {
+    // 5 requests per second per conversation, https://dev.frontapp.com/docs/rate-limiting#additional-burst-rate-limiting
+    this.burstRateLimiter = createRetryRateLimiter(200);
+  }
+
+  private burstFetch = async <T = unknown>(
+    url: string | URL,
+    init?: RequestInit,
+  ) => {
+    return await this.burstRateLimiter.schedule(async () =>
+      jsonFetch<T>(url, {
+        ...init,
+        headers: {
+          ...init?.headers,
+          Authorization: `Bearer ${await this.getAuthToken()}`,
+        },
+      }),
+    );
+  };
 
   private async getAuthToken() {
     if (this.token) return this.token;
@@ -184,31 +203,23 @@ export class FrontApplicationClient {
   }
 
   public async sendIncomingMessages(msg: Front.AppChannelInboundMessage) {
-    const token = await this.getAuthToken();
     const url = new URL(
       `/channels/${this.channelId}/inbound_messages`,
       this.host,
     );
-    return await jsonFetch<Front.AppChannelSyncResponse>(url, {
+    return await this.burstFetch<Front.AppChannelSyncResponse>(url, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
       body: JSON.stringify(msg),
     });
   }
 
   public async sendOutgoingMessages(msg: Front.AppChannelOutboundMessage) {
-    const token = await this.getAuthToken();
     const url = new URL(
       `/channels/${this.channelId}/outbound_messages`,
       this.host,
     );
-    return await jsonFetch<Front.AppChannelSyncResponse>(url, {
+    return await this.burstFetch<Front.AppChannelSyncResponse>(url, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
       body: JSON.stringify(msg),
     });
   }

--- a/app/api/front/utils.ts
+++ b/app/api/front/utils.ts
@@ -4,13 +4,10 @@ import type { HandoffChatMessage, VerifiedUserData } from "@/types";
 import {
   FrontApplicationClient,
   FrontCoreClient,
-  RetryableStatusCodes,
 } from "@/app/api/front/client";
 import Keyv from "keyv";
 import { Cacheable, KeyvCacheableMemory } from "cacheable";
 import { getRedisCache } from "@/app/api/server/lib/redis";
-import { JsonFetchError } from "@/lib/jsonFetch";
-import Bottleneck from "bottleneck";
 import { DateTime } from "luxon";
 
 let channelCache: Cacheable | undefined;


### PR DESCRIPTION
Refactor retry logic for FrontApplicationClient to reuse the shared rate-limiting logic from the FrontCoreClient