### PR TITLE
APP-245: handle stringifying objects and arrays

### DIFF
--- a/__tests__/app/api/create/route.test.ts
+++ b/__tests__/app/api/create/route.test.ts
@@ -241,6 +241,9 @@ describe("POST /api/create", () => {
             otherValue: "otherValue",
             firstName: "John",
             lastName: "Doe",
+            objectField: { key: "value" },
+            arrayField: ["one", "two"],
+            nullField: null,
           }),
           mockUnsignedData,
         );
@@ -264,6 +267,18 @@ describe("POST /api/create", () => {
             },
             lastName: {
               value: "Doe",
+              visibility: MavenAGI.VisibilityType.Visible,
+            },
+            objectField: {
+              value: JSON.stringify({ key: "value" }, null, 4),
+              visibility: MavenAGI.VisibilityType.Visible,
+            },
+            arrayField: {
+              value: JSON.stringify(["one", "two"], null, 4),
+              visibility: MavenAGI.VisibilityType.Visible,
+            },
+            nullField: {
+              value: null,
               visibility: MavenAGI.VisibilityType.Visible,
             },
           },

--- a/app/api/create/route.ts
+++ b/app/api/create/route.ts
@@ -64,7 +64,12 @@ async function createOrUpdateUser(
     const data: Record<string, MavenAGI.UserData> = {};
     Object.entries(rest).forEach(([key, value]) => {
       data[key] = {
-        value: (value as any).toString?.() || value,
+        value:
+          value === null
+            ? null
+            : typeof value === "object"
+              ? JSON.stringify(value, null, 4)
+              : (value as any).toString?.() || value,
         visibility: MavenAGI.VisibilityType.Visible,
       };
     });


### PR DESCRIPTION
The customFields object provided by scratchpay is turning into `[object Object]` instead of properly serialized output. 

<img width="1955" alt="Screenshot 2025-01-29 at 12 41 18 PM" src="https://github.com/user-attachments/assets/7c3ff7a4-7a3c-41cd-aa56-4ef18cd0d5af" />
