### PR TITLE
feat: [chat][demo page] Prime chat with today's date

### DIFF
--- a/__tests__/app/demo/[organizationId]/[agentId]/Widget.test.tsx
+++ b/__tests__/app/demo/[organizationId]/[agentId]/Widget.test.tsx
@@ -1,0 +1,100 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Widget from "@/app/demo/[organizationId]/[agentId]/Widget";
+
+describe("Widget", () => {
+  const mockWidgetLoadPayload = {
+    organizationId: "test-org",
+    agentId: "test-agent",
+    envPrefix: "test",
+    bgColor: "#000000",
+    signedUserData: "signed-data",
+    unsignedUserData: {
+      name: "Test User",
+    },
+    customData: {
+      key: "value",
+    },
+  };
+
+  beforeEach(() => {
+    // Reset any mocks and clear the DOM
+    vi.clearAllMocks();
+  });
+
+  it("renders widget script tags", () => {
+    const { container } = render(
+      <Widget widgetLoadPayload={mockWidgetLoadPayload} />,
+    );
+
+    const scripts = container.getElementsByTagName("script");
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]).toHaveAttribute("src", "/js/widget.js");
+    expect(scripts[0]).toHaveAttribute("defer");
+  });
+
+  it("includes today's date with timezone in unsigned user data", () => {
+    const { container } = render(
+      <Widget widgetLoadPayload={mockWidgetLoadPayload} />,
+    );
+
+    const widgetScript = container.getElementsByTagName("script")[1];
+    const scriptContent = widgetScript.innerHTML;
+
+    // Verify the script content includes the date with timezone
+    expect(scriptContent).toContain("todaysDate");
+    expect(scriptContent).toMatch(
+      /\d{1,2}\/\d{1,2}\/\d{4},\s+\d{1,2}:\d{2}:\d{2}\s+(AM|PM)\s+[A-Za-z\s]+Time/,
+    ); // Date format with timezone check
+  });
+
+  it("preserves existing unsigned user data while adding date", () => {
+    const { container } = render(
+      <Widget widgetLoadPayload={mockWidgetLoadPayload} />,
+    );
+
+    const widgetScript = container.getElementsByTagName("script")[1];
+    const scriptContent = widgetScript.innerHTML;
+
+    // Check original data is preserved
+    expect(scriptContent).toContain('"name":"Test User"');
+    // Check date was added
+    expect(scriptContent).toContain("todaysDate");
+  });
+
+  it("generates correct widget load script with all payload data", () => {
+    const { container } = render(
+      <Widget widgetLoadPayload={mockWidgetLoadPayload} />,
+    );
+
+    const widgetScript = container.getElementsByTagName("script")[1];
+    const scriptContent = widgetScript.innerHTML;
+
+    // Verify all payload properties are included
+    expect(scriptContent).toContain('"organizationId":"test-org"');
+    expect(scriptContent).toContain('"agentId":"test-agent"');
+    expect(scriptContent).toContain('"envPrefix":"test"');
+    expect(scriptContent).toContain('"bgColor":"#000000"');
+    expect(scriptContent).toContain('"signedUserData":"signed-data"');
+    expect(scriptContent).toContain('"key":"value"');
+  });
+
+  it("handles payload without optional fields", () => {
+    const minimalPayload = {
+      organizationId: "test-org",
+      agentId: "test-agent",
+    };
+
+    const { container } = render(<Widget widgetLoadPayload={minimalPayload} />);
+
+    const widgetScript = container.getElementsByTagName("script")[1];
+    const scriptContent = widgetScript.innerHTML;
+
+    // Verify required fields are present
+    expect(scriptContent).toContain('"organizationId":"test-org"');
+    expect(scriptContent).toContain('"agentId":"test-agent"');
+    // Verify optional fields are handled gracefully
+    expect(scriptContent).not.toContain('"signedUserData"');
+    expect(scriptContent).not.toContain('"bgColor"');
+  });
+});

--- a/__tests__/app/demo/[organizationId]/[agentId]/page.test.tsx
+++ b/__tests__/app/demo/[organizationId]/[agentId]/page.test.tsx
@@ -87,7 +87,8 @@ describe("DemoPage", () => {
             "firstName":"[^"]+",
             "lastName":"[^"]+",
             "id":"[^"]+",
-            "email":"[^"]+"
+            "email":"[^"]+",
+            "todaysDate":"[^"]+"
           },
           "customData":{
           }

--- a/app/demo/[organizationId]/[agentId]/Widget.tsx
+++ b/app/demo/[organizationId]/[agentId]/Widget.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+type WidgetLoadPayload = {
+  envPrefix?: string;
+  organizationId: string;
+  agentId: string;
+  bgColor?: string;
+  signedUserData?: string;
+  unsignedUserData?: Record<string, any>;
+  customData?: Record<string, any>;
+};
+
+export default function Widget({
+  widgetLoadPayload,
+}: {
+  widgetLoadPayload: WidgetLoadPayload;
+}) {
+  const localizedDate = new Date().toLocaleString("en-US", {
+    timeZoneName: "long",
+  });
+  widgetLoadPayload.unsignedUserData = {
+    ...(widgetLoadPayload.unsignedUserData || {}),
+    todaysDate: localizedDate,
+  };
+
+  return (
+    <>
+      <script src="/js/widget.js" defer></script>
+      <script
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: `
+    addEventListener("load", function () {
+      Maven.ChatWidget.load(${JSON.stringify(widgetLoadPayload)});
+    });`,
+        }}
+      ></script>
+    </>
+  );
+}

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -5,13 +5,16 @@ import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
 
+const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 // Move faker data generation outside the component
 const mockUserData = {
   firstName: faker.person.firstName(),
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: Date(),
+  todaysDate: new Intl.DateTimeFormat(undefined, { timeZone }).format(
+    new Date(),
+  ),
 };
 
 console.log("mockUserData", mockUserData);

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -5,6 +5,7 @@ import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
 
+const now = new Date();
 const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 // Move faker data generation outside the component
 const mockUserData = {
@@ -12,9 +13,7 @@ const mockUserData = {
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: new Intl.DateTimeFormat(undefined, { timeZone }).format(
-    new Date(),
-  ),
+  todaysDate: new Intl.DateTimeFormat(undefined, { timeZone }).format(now),
 };
 
 console.log("mockUserData", mockUserData);

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -11,8 +11,10 @@ const mockUserData = {
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: new Date().toLocaleString(),
+  todaysDate: Date(),
 };
+
+console.log("mockUserData", mockUserData);
 
 export default async function Page({
   params,

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -5,12 +5,22 @@ import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
 
+const today = new Date();
+const currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const formattedToday = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: currentTimeZone,
+}).format(today);
+
 // Move faker data generation outside the component
 const mockUserData = {
   firstName: faker.person.firstName(),
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
+  todaysDate: formattedToday,
 };
 
 export default async function Page({

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -5,18 +5,23 @@ import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
 
-const now = new Date();
-const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const today = new Date();
+const currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const formattedToday = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: currentTimeZone,
+}).format(today);
+
 // Move faker data generation outside the component
 const mockUserData = {
   firstName: faker.person.firstName(),
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: new Intl.DateTimeFormat(undefined, { timeZone }).format(now),
+  todaysDate: formattedToday,
 };
-
-console.log("mockUserData", mockUserData);
 
 export default async function Page({
   params,

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -5,22 +5,13 @@ import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
 
-const today = new Date();
-const currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-const formattedToday = new Intl.DateTimeFormat(undefined, {
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-  timeZone: currentTimeZone,
-}).format(today);
-
 // Move faker data generation outside the component
 const mockUserData = {
   firstName: faker.person.firstName(),
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: formattedToday,
+  todaysDate: Date(),
 };
 
 export default async function Page({

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -1,11 +1,10 @@
-"use client";
-
 import { headers } from "next/headers";
 import { faker } from "@faker-js/faker";
 import { getPublicAppSettings } from "@/app/actions";
 import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
+import Widget from "./Widget";
 
 // Move faker data generation outside the component
 const mockUserData = {
@@ -13,7 +12,6 @@ const mockUserData = {
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: new Date().toLocaleString(),
 };
 
 export default async function Page({
@@ -77,15 +75,7 @@ export default async function Page({
         height: "100vh",
       }}
     >
-      <script src="/js/widget.js" defer></script>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-    addEventListener("load", function () {
-      Maven.ChatWidget.load(${JSON.stringify(widgetLoadPayload)});
-    });`,
-        }}
-      ></script>
+      <Widget widgetLoadPayload={widgetLoadPayload} />
     </div>
   );
 }

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { headers } from "next/headers";
 import { faker } from "@faker-js/faker";
 import { getPublicAppSettings } from "@/app/actions";
@@ -11,7 +13,7 @@ const mockUserData = {
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: Date(),
+  todaysDate: new Date().toLocaleString(),
 };
 
 export default async function Page({

--- a/app/demo/[organizationId]/[agentId]/page.tsx
+++ b/app/demo/[organizationId]/[agentId]/page.tsx
@@ -5,22 +5,13 @@ import { generateSignedUserData } from "./actions";
 import { notFound } from "next/navigation";
 import backgroundImg from "@/assets/background/bg.jpg";
 
-const today = new Date();
-const currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-const formattedToday = new Intl.DateTimeFormat(undefined, {
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-  timeZone: currentTimeZone,
-}).format(today);
-
 // Move faker data generation outside the component
 const mockUserData = {
   firstName: faker.person.firstName(),
   lastName: faker.person.lastName(),
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  todaysDate: formattedToday,
+  todaysDate: new Date().toLocaleString(),
 };
 
 export default async function Page({


### PR DESCRIPTION
A number of demo's want Maven chat to know what today's date is. Until the platform's prompt handles this universally, we're using `unsignedUserData` to pass to to the demo page widget so the chat is primed with today's date alongside the mock user data.