### PR TITLE
Soln 94 create online rules for agent only allow live agent handoff

### DIFF
--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isHandoffAvailable } from "@/app/actions";
+import { getAppSettings } from "@/app/api/server/utils";
+
+vi.mock("@/app/api/server/utils", () => ({
+  getAppSettings: vi.fn(),
+}));
+
+describe("isHandoffAvailable", () => {
+  const mockFetch = vi.fn();
+  global.fetch = mockFetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns undefined when handoff configuration is not salesforce", async () => {
+    vi.mocked(getAppSettings).mockResolvedValue({
+      handoffConfiguration: {
+        type: "zendesk",
+      },
+    } as any);
+
+    const result = await isHandoffAvailable("org-id", "agent-id");
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it("returns undefined when availability check is disabled", async () => {
+    vi.mocked(getAppSettings).mockResolvedValue({
+      handoffConfiguration: {
+        type: "salesforce",
+        enableAvailabilityCheck: false,
+      },
+    } as any);
+
+    const result = await isHandoffAvailable("org-id", "agent-id");
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it("returns undefined on fetch error", async () => {
+    vi.mocked(getAppSettings).mockResolvedValue({
+      handoffConfiguration: {
+        type: "salesforce",
+        enableAvailabilityCheck: true,
+        chatHostUrl: "https://test.com",
+        orgId: "org-id",
+        deploymentId: "dep-id",
+        chatButtonId: "button-id",
+      },
+    } as any);
+
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    const result = await isHandoffAvailable("org-id", "agent-id");
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it("returns undefined on non-200 response", async () => {
+    vi.mocked(getAppSettings).mockResolvedValue({
+      handoffConfiguration: {
+        type: "salesforce",
+        enableAvailabilityCheck: true,
+        chatHostUrl: "https://test.com",
+        orgId: "org-id",
+        deploymentId: "dep-id",
+        chatButtonId: "button-id",
+      },
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+    });
+
+    const result = await isHandoffAvailable("org-id", "agent-id");
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it("returns false when agents are not available", async () => {
+    vi.mocked(getAppSettings).mockResolvedValue({
+      handoffConfiguration: {
+        type: "salesforce",
+        enableAvailabilityCheck: true,
+        chatHostUrl: "https://test.com",
+        orgId: "org-id",
+        deploymentId: "dep-id",
+        chatButtonId: "button-id",
+      },
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          messages: [
+            {
+              type: "Availability",
+              message: {
+                results: [
+                  {
+                    id: "button-id",
+                    isAvailable: false,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await isHandoffAvailable("org-id", "agent-id");
+    expect(result).toEqual({ success: true, data: false });
+  });
+
+  it("returns true when agents are available", async () => {
+    vi.mocked(getAppSettings).mockResolvedValue({
+      handoffConfiguration: {
+        type: "salesforce",
+        enableAvailabilityCheck: true,
+        chatHostUrl: "https://test.com",
+        orgId: "org-id",
+        deploymentId: "dep-id",
+        chatButtonId: "button-id",
+      },
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          messages: [
+            {
+              type: "Availability",
+              message: {
+                results: [
+                  {
+                    id: "button-id",
+                    isAvailable: true,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await isHandoffAvailable("org-id", "agent-id");
+    expect(result).toEqual({ success: true, data: true });
+  });
+});

--- a/__tests__/lib/handoff/SalesforceStrategy.test.ts
+++ b/__tests__/lib/handoff/SalesforceStrategy.test.ts
@@ -136,6 +136,9 @@ describe("SalesforceServerStrategy", () => {
   });
 
   it("returns true on fetch error", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const strategy = new SalesforceServerStrategy({
       type: "salesforce",
       enableAvailabilityCheck: true,
@@ -149,6 +152,9 @@ describe("SalesforceServerStrategy", () => {
 
     const result = await strategy.fetchHandoffAvailability();
     expect(result).toBe(true);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("returns true on non-200 response", async () => {

--- a/__tests__/lib/handoff/SalesforceStrategy.test.ts
+++ b/__tests__/lib/handoff/SalesforceStrategy.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { SalesforceStrategy } from "@/lib/handoff/SalesforceStrategy";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  SalesforceStrategy,
+  SalesforceServerStrategy,
+} from "@/lib/handoff/SalesforceStrategy";
 import {
   createUserMessage,
   createBotMessage,
@@ -111,5 +114,197 @@ describe("SalesforceStrategy", () => {
         "/api/salesforce/conversations",
       );
     });
+  });
+});
+
+describe("SalesforceServerStrategy", () => {
+  const mockFetch = vi.fn();
+  global.fetch = mockFetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when availability check is disabled", async () => {
+    const strategy = new SalesforceServerStrategy({
+      type: "salesforce",
+      enableAvailabilityCheck: false,
+    } as any);
+
+    const result = await strategy.fetchHandoffAvailability();
+    expect(result).toBe(true);
+  });
+
+  it("returns true on fetch error", async () => {
+    const strategy = new SalesforceServerStrategy({
+      type: "salesforce",
+      enableAvailabilityCheck: true,
+      chatHostUrl: "https://test.com",
+      orgId: "org-id",
+      deploymentId: "dep-id",
+      chatButtonId: "button-id",
+    } as any);
+
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    const result = await strategy.fetchHandoffAvailability();
+    expect(result).toBe(true);
+  });
+
+  it("returns true on non-200 response", async () => {
+    const strategy = new SalesforceServerStrategy({
+      type: "salesforce",
+      enableAvailabilityCheck: true,
+      chatHostUrl: "https://test.com",
+      orgId: "org-id",
+      deploymentId: "dep-id",
+      chatButtonId: "button-id",
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+    });
+
+    const result = await strategy.fetchHandoffAvailability();
+    expect(result).toBe(true);
+  });
+
+  it("returns false when agents are not available", async () => {
+    const strategy = new SalesforceServerStrategy({
+      type: "salesforce",
+      enableAvailabilityCheck: true,
+      chatHostUrl: "https://test.com",
+      orgId: "org-id",
+      deploymentId: "dep-id",
+      chatButtonId: "button-id",
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          messages: [
+            {
+              type: "Availability",
+              message: {
+                results: [
+                  {
+                    id: "button-id",
+                    isAvailable: false,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await strategy.fetchHandoffAvailability();
+    expect(result).toBe(false);
+  });
+
+  it("returns true when agents are available", async () => {
+    const strategy = new SalesforceServerStrategy({
+      type: "salesforce",
+      enableAvailabilityCheck: true,
+      chatHostUrl: "https://test.com",
+      orgId: "org-id",
+      deploymentId: "dep-id",
+      chatButtonId: "button-id",
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          messages: [
+            {
+              type: "Availability",
+              message: {
+                results: [
+                  {
+                    id: "button-id",
+                    isAvailable: true,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await strategy.fetchHandoffAvailability();
+    expect(result).toBe(true);
+  });
+
+  it("returns true when no matching button ID is found", async () => {
+    const strategy = new SalesforceServerStrategy({
+      type: "salesforce",
+      enableAvailabilityCheck: true,
+      chatHostUrl: "https://test.com",
+      orgId: "org-id",
+      deploymentId: "dep-id",
+      chatButtonId: "button-id",
+    } as any);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          messages: [
+            {
+              type: "Availability",
+              message: {
+                results: [
+                  {
+                    id: "different-button-id",
+                    isAvailable: true,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await strategy.fetchHandoffAvailability();
+    expect(result).toBe(true);
+  });
+
+  it("verifies the correct URL and headers are used", async () => {
+    const config = {
+      type: "salesforce",
+      enableAvailabilityCheck: true,
+      chatHostUrl: "https://test.com",
+      orgId: "org-id",
+      deploymentId: "dep-id",
+      chatButtonId: "button-id",
+    } as any;
+
+    const strategy = new SalesforceServerStrategy(config);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ messages: [] }),
+    });
+
+    await strategy.fetchHandoffAvailability();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        config.chatHostUrl + "/chat/rest/Visitor/Availability",
+      ),
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "X-LIVEAGENT-API-VERSION": expect.any(String),
+        },
+      }),
+    );
+
+    const url = new URL(mockFetch.mock.calls[0][0]);
+    expect(url.searchParams.get("org_id")).toBe(config.orgId);
+    expect(url.searchParams.get("deployment_id")).toBe(config.deploymentId);
+    expect(url.searchParams.get("Availability.ids")).toBe(config.chatButtonId);
   });
 });

--- a/__tests__/packages/components/chat/EscalationFormDisplay.test.tsx
+++ b/__tests__/packages/components/chat/EscalationFormDisplay.test.tsx
@@ -94,10 +94,7 @@ describe("EscalationFormDisplay", () => {
         availabilityFallbackMessage,
       },
     });
-    (isHandoffAvailable as any).mockResolvedValue({
-      success: true,
-      data: isAvailable,
-    });
+    (isHandoffAvailable as any).mockResolvedValue(isAvailable);
 
     return render(
       <ChatContext.Provider value={mockProviderValue}>
@@ -122,7 +119,7 @@ describe("EscalationFormDisplay", () => {
 
     // Resolve the availability check
     await act(async () => {
-      resolvePromise!({ success: true, data: true });
+      resolvePromise!(true);
     });
 
     // Form should now be visible
@@ -282,7 +279,7 @@ describe("EscalationFormDisplay", () => {
 
     // Resolving the promise should not affect the UI
     await act(async () => {
-      resolvePromise!({ success: true, data: true });
+      resolvePromise!(true);
     });
 
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();

--- a/__tests__/packages/components/chat/EscalationFormDisplay.test.tsx
+++ b/__tests__/packages/components/chat/EscalationFormDisplay.test.tsx
@@ -1,8 +1,17 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import EscalationFormDisplay from "@/packages/components/chat/EscalationFormDisplay";
 import { ChatContext } from "@/packages/components/chat/Chat";
 import { useAuth } from "@/app/providers/AuthProvider";
+import { useSettings } from "@/app/providers/SettingsProvider";
+import { useParams } from "next/navigation";
+import { isHandoffAvailable } from "@/app/actions";
 
 // Mock the next-intl translations
 vi.mock("next-intl", () => ({
@@ -11,7 +20,26 @@ vi.mock("next-intl", () => ({
 
 // Mock the auth hook
 vi.mock("@/app/providers/AuthProvider", () => ({
-  useAuth: vi.fn(),
+  useAuth: vi.fn().mockReturnValue({
+    isAuthenticated: false,
+  }),
+}));
+
+vi.mock("@/app/providers/SettingsProvider", () => ({
+  useSettings: vi.fn().mockReturnValue({
+    handoffConfiguration: {
+      enableAvailabilityCheck: false,
+      availabilityFallbackMessage: "agents_unavailable",
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+}));
+
+vi.mock("@/app/actions", () => ({
+  isHandoffAvailable: vi.fn(),
 }));
 
 const mockInitializeHandoff = vi.fn();
@@ -23,15 +51,53 @@ const mockProviderValue = {
   agentName: "Test Agent",
   isHandoff: false,
   handleEndHandoff: vi.fn(),
+  addMessage: vi.fn(),
+  conversationId: "test-conv-id",
+  messages: [],
+  shouldSupressHandoffInputDisplay: false,
 };
 
 describe("EscalationFormDisplay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (useParams as any).mockReturnValue({
+      organizationId: "org-id",
+      agentId: "agent-id",
+    });
+    (useSettings as any).mockReturnValue({
+      handoffConfiguration: {
+        enableAvailabilityCheck: false,
+        availabilityFallbackMessage: "agents_unavailable",
+      },
+    });
   });
 
-  const renderComponent = (isAuthenticated = false) => {
+  const renderComponent = (
+    config: {
+      isAuthenticated?: boolean;
+      enableAvailabilityCheck?: boolean;
+      availabilityFallbackMessage?: string;
+      isAvailable?: boolean;
+    } = {},
+  ) => {
+    const {
+      isAuthenticated = false,
+      enableAvailabilityCheck = false,
+      availabilityFallbackMessage = "agents_unavailable",
+      isAvailable = true,
+    } = config;
+
     (useAuth as any).mockReturnValue({ isAuthenticated });
+    (useSettings as any).mockReturnValue({
+      handoffConfiguration: {
+        enableAvailabilityCheck,
+        availabilityFallbackMessage,
+      },
+    });
+    (isHandoffAvailable as any).mockResolvedValue({
+      success: true,
+      data: isAvailable,
+    });
 
     return render(
       <ChatContext.Provider value={mockProviderValue}>
@@ -40,15 +106,73 @@ describe("EscalationFormDisplay", () => {
     );
   };
 
+  it("shows loading state initially when availability check enabled", async () => {
+    let resolvePromise: (value: any) => void;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    (isHandoffAvailable as any).mockReturnValue(promise);
+
+    renderComponent({ enableAvailabilityCheck: true });
+
+    // Initial loading state
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.queryByText("connect_to_live_agent")).not.toBeInTheDocument();
+
+    // Resolve the availability check
+    await act(async () => {
+      resolvePromise!({ success: true, data: true });
+    });
+
+    // Form should now be visible
+    await waitFor(() => {
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+      expect(screen.getByText("connect_to_live_agent")).toBeInTheDocument();
+    });
+  });
+
+  it("shows fallback message when agents are not available", async () => {
+    renderComponent({
+      enableAvailabilityCheck: true,
+      isAvailable: false,
+      availabilityFallbackMessage: "Custom fallback message",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom fallback message")).toBeInTheDocument();
+    });
+  });
+
+  it("shows form when availability check is disabled", async () => {
+    renderComponent({ enableAvailabilityCheck: false });
+
+    await waitFor(() => {
+      expect(screen.getByText("connect_to_live_agent")).toBeInTheDocument();
+    });
+  });
+
+  it("shows form when agents are available", async () => {
+    renderComponent({
+      enableAvailabilityCheck: true,
+      isAvailable: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("connect_to_live_agent")).toBeInTheDocument();
+    });
+  });
+
   it("submits the form when the button is clicked", async () => {
     renderComponent();
 
-    // Add email input first, required
-    const emailInput = screen.getByPlaceholderText("email_placeholder");
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    await waitFor(() => {
+      const emailInput = screen.getByPlaceholderText("email_placeholder");
+      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
 
-    const submitButton = screen.getByText("connect_to_live_agent");
-    fireEvent.click(submitButton);
+      const submitButton = screen.getByText("connect_to_live_agent");
+      fireEvent.click(submitButton);
+    });
 
     await waitFor(() => {
       expect(mockInitializeHandoff).toHaveBeenCalledWith({
@@ -57,33 +181,36 @@ describe("EscalationFormDisplay", () => {
     });
   });
 
-  it("renders email input when user is not authenticated", () => {
-    renderComponent(false);
-    expect(
-      screen.getByPlaceholderText("email_placeholder"),
-    ).toBeInTheDocument();
+  it("renders email input when user is not authenticated", async () => {
+    renderComponent({ isAuthenticated: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("email_placeholder"),
+      ).toBeInTheDocument();
+    });
   });
 
-  it("does not render email input when user is authenticated", () => {
-    renderComponent(true);
-    expect(
-      screen.queryByPlaceholderText("email_placeholder"),
-    ).not.toBeInTheDocument();
-  });
+  it("does not render email input when user is authenticated", async () => {
+    renderComponent({ isAuthenticated: true });
 
-  it("shows connect button with correct text", () => {
-    renderComponent();
-    expect(screen.getByText("connect_to_live_agent")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByPlaceholderText("email_placeholder"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("submits form with email for unauthenticated user", async () => {
-    renderComponent(false);
+    renderComponent({ isAuthenticated: false });
 
-    const emailInput = screen.getByPlaceholderText("email_placeholder");
-    const submitButton = screen.getByText("connect_to_live_agent");
+    await waitFor(async () => {
+      const emailInput = screen.getByPlaceholderText("email_placeholder");
+      const submitButton = screen.getByText("connect_to_live_agent");
 
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    fireEvent.click(submitButton);
+      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+      fireEvent.click(submitButton);
+    });
 
     await waitFor(() => {
       expect(mockInitializeHandoff).toHaveBeenCalledWith({
@@ -93,10 +220,12 @@ describe("EscalationFormDisplay", () => {
   });
 
   it("submits form without email for authenticated user", async () => {
-    renderComponent(true);
+    renderComponent({ isAuthenticated: true });
 
-    const submitButton = screen.getByText("connect_to_live_agent");
-    fireEvent.click(submitButton);
+    await waitFor(async () => {
+      const submitButton = screen.getByText("connect_to_live_agent");
+      fireEvent.click(submitButton);
+    });
 
     await waitFor(() => {
       expect(mockInitializeHandoff).toHaveBeenCalledWith({
@@ -105,42 +234,58 @@ describe("EscalationFormDisplay", () => {
     });
   });
 
-  it("displays error message when submission fails and keeps component mounted", async () => {
+  it("displays error message when submission fails", async () => {
     vi.spyOn(console, "error").mockImplementationOnce(() => {});
     mockInitializeHandoff.mockRejectedValueOnce(new Error("Test error"));
-    renderComponent(false);
+    renderComponent();
 
-    const form = screen.getByRole("form");
-    fireEvent.submit(form);
+    await waitFor(async () => {
+      const form = screen.getByRole("form");
+      fireEvent.submit(form);
+    });
 
     await waitFor(() => {
-      // Verify error message is shown
       expect(screen.getByText("Error")).toBeInTheDocument();
       expect(
         screen.getByText("Failed to initiate chat session. Please try again."),
       ).toBeInTheDocument();
-
-      // Verify form is no longer visible
-      expect(screen.queryByRole("form")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText("connect_to_live_agent"),
-      ).not.toBeInTheDocument();
     });
-
-    // Verify component itself is still mounted (the div wrapper)
-    expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("hides form after successful submission", async () => {
-    renderComponent(false);
+    renderComponent();
 
-    const form = screen.getByRole("form");
-    fireEvent.submit(form);
+    await waitFor(async () => {
+      const form = screen.getByRole("form");
+      fireEvent.submit(form);
+    });
 
     await waitFor(() => {
       expect(
         screen.queryByText("connect_to_live_agent"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("does not show loading state when availability check is disabled", async () => {
+    let resolvePromise: (value: any) => void;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    (isHandoffAvailable as any).mockReturnValue(promise);
+
+    renderComponent({ enableAvailabilityCheck: false });
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.getByText("connect_to_live_agent")).toBeInTheDocument();
+
+    // Resolving the promise should not affect the UI
+    await act(async () => {
+      resolvePromise!({ success: true, data: true });
+    });
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.getByText("connect_to_live_agent")).toBeInTheDocument();
   });
 });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -162,7 +162,7 @@ export async function isHandoffAvailable(
       organizationId,
       agentId,
     );
-    console.log({ handoffConfiguration });
+
     if (
       handoffConfiguration?.type !== "salesforce" ||
       !handoffConfiguration.enableAvailabilityCheck

--- a/app/api/salesforce/utils.ts
+++ b/app/api/salesforce/utils.ts
@@ -9,11 +9,13 @@ import type {
   SalesforceMessageType,
 } from "@/types/salesforce";
 import { SALESFORCE_MESSAGE_TYPES } from "@/types/salesforce";
+import { SALESFORCE_API_VERSION } from "@/app/constants/handoff";
 
 export const SALESFORCE_CHAT_PROMPT_MESSAGE_NAMES = [
   "Management Center",
   "Management Center with Maven",
 ];
+
 export const SALESFORCE_CHAT_PROMPT_MESSAGE_TEXTS = [
   "Please enter the subject",
 ];
@@ -29,7 +31,7 @@ export const SALESFORCE_ALLOWED_MESSAGE_TYPES: SalesforceMessageType[] = [
 ];
 
 export const SALESFORCE_API_BASE_HEADERS = {
-  "X-LIVEAGENT-API-VERSION": "34",
+  "X-LIVEAGENT-API-VERSION": SALESFORCE_API_VERSION,
   "Access-Control-Allow-Origin": "*",
 };
 
@@ -103,7 +105,7 @@ export async function sendChatMessage(
 }
 
 export const SESSION_CREDENTIALS_REQUEST_HEADERS = {
-  "X-LIVEAGENT-API-VERSION": "34",
+  "X-LIVEAGENT-API-VERSION": SALESFORCE_API_VERSION,
   "X-LIVEAGENT-AFFINITY": "",
   "Access-Control-Allow-Origin": "*",
 };

--- a/app/constants/handoff.ts
+++ b/app/constants/handoff.ts
@@ -4,3 +4,5 @@ export enum HandoffStatus {
   NOT_INITIALIZED = "not_initialized",
   FAILED = "failed",
 }
+
+export const SALESFORCE_API_VERSION = "34";

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,9 @@
 import { getMavenAGIClient } from "./app";
 import { SALESFORCE_API_VERSION } from "./app/constants/handoff";
+
+const ESCALATE_ACTION_ID = "escalate-to-agent";
+const ESCALATE_ACTION_NAME = "Escalate to Live Agent";
+
 const defaultModule = {
   async postInstall({
     settings,
@@ -53,9 +57,9 @@ const defaultModule = {
     // Escalate action
     const result = await client.actions.createOrUpdate({
       actionId: {
-        referenceId: "escalate-to-agent",
+        referenceId: ESCALATE_ACTION_ID,
       },
-      name: "escalate-live-agent",
+      name: ESCALATE_ACTION_NAME,
       description,
       userInteractionRequired: true,
       userFormParameters: [
@@ -97,25 +101,10 @@ const defaultModule = {
     settings,
   }: {
     actionId: string;
-    parameters: Record<string, any>;
-    organizationId: string;
-    agentId: string;
-    conversationId: string;
-    memberId: string;
-    memberEmail: string;
-    memberFirstName: string;
-    memberLastName: string;
-    memberPhone: string;
-    memberCountry: string;
-    memberLanguage: string;
-    memberTimezone: string;
-    memberIpAddress: string;
-    memberDevice: string;
-    memberBrowser: string;
-    memberOperatingSystem: string;
     settings: AppSettings;
   }) {
-    if (actionId === "escalate-to-agent") {
+    console.log("executeAction", actionId, settings);
+    if (actionId === ESCALATE_ACTION_ID) {
       if (settings.handoffConfiguration) {
         try {
           const parsedHandoffConfiguration: HandoffConfiguration = JSON.parse(

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import { getMavenAGIClient } from "./app";
-import { SALESFORCE_API_VERSION } from "./app/constants/handoff";
 
 const ESCALATE_ACTION_ID = "escalate-to-agent";
 const ESCALATE_ACTION_NAME = "Escalate to Live Agent";

--- a/index.ts
+++ b/index.ts
@@ -96,53 +96,8 @@ const defaultModule = {
     });
   },
 
-  async executeAction({
-    actionId,
-    settings,
-  }: {
-    actionId: string;
-    settings: AppSettings;
-  }) {
-    console.log("executeAction", actionId, settings);
+  async executeAction({ actionId }: { actionId: string }) {
     if (actionId === ESCALATE_ACTION_ID) {
-      if (settings.handoffConfiguration) {
-        try {
-          const parsedHandoffConfiguration: HandoffConfiguration = JSON.parse(
-            settings.handoffConfiguration,
-          );
-          if (parsedHandoffConfiguration.type === "salesforce") {
-            const salesforceHandoffConfiguration =
-              parsedHandoffConfiguration as SalesforceHandoffConfiguration;
-            if (salesforceHandoffConfiguration.enableAvailabilityCheck) {
-              const url =
-                salesforceHandoffConfiguration.chatHostUrl +
-                new URLSearchParams({
-                  org_id: salesforceHandoffConfiguration.orgId,
-                  deployment_id: salesforceHandoffConfiguration.deploymentId,
-                  "Availability.ids":
-                    salesforceHandoffConfiguration.chatButtonId,
-                });
-              const response = await fetch(
-                `${url}/chat/rest/Visitor/Availability`,
-                {
-                  method: "GET",
-                  headers: {
-                    "X-LIVEAGENT-API-VERSION": SALESFORCE_API_VERSION,
-                  },
-                },
-              );
-              if (response.ok) {
-                const data = await response.json();
-                console.log(data);
-              } else {
-                console.error("Failed to check availability", response);
-              }
-            }
-          }
-        } catch (e) {
-          console.error("Failed to parse ESCALATION_TOPICS", e);
-        }
-      }
       return "Escalating to agent...";
     }
 

--- a/lib/handoff/HandoffStrategy.ts
+++ b/lib/handoff/HandoffStrategy.ts
@@ -31,6 +31,7 @@ export interface HandoffStrategy<T = HandoffChatMessage> {
 
 export interface ServerHandoffStrategy {
   isLiveHandoffAvailable?: () => Promise<boolean>;
+  fetchHandoffAvailability?: () => Promise<boolean>;
 }
 
 export interface HandoffContext {

--- a/lib/handoff/SalesforceStrategy.ts
+++ b/lib/handoff/SalesforceStrategy.ts
@@ -1,3 +1,4 @@
+import { SALESFORCE_API_VERSION } from "@/app/constants/handoff";
 import {
   type HandoffStrategy,
   MESSAGE_TYPES_FOR_HANDOFF_CREATION,
@@ -14,6 +15,7 @@ import {
   SALESFORCE_CHAT_SUBJECT_HEADER_KEY,
   SALESFORCE_MESSAGE_TYPES,
   SALESFORCE_MESSAGE_TYPES_FOR_HANDOFF_TERMINATION,
+  type ChatAvailabilityResponse,
 } from "@/types/salesforce";
 
 export class SalesforceStrategy implements HandoffStrategy<Message> {
@@ -100,5 +102,48 @@ export class SalesforceStrategy implements HandoffStrategy<Message> {
 
 export class SalesforceServerStrategy implements ServerHandoffStrategy {
   constructor(private configuration: SalesforceHandoffConfiguration) {}
-  isLiveHandoffAvailable? = () => Promise.resolve(true);
+
+  isLiveHandoffAvailable? = async () => {
+    return true;
+  };
+
+  fetchHandoffAvailability = async () => {
+    if (!this.configuration.enableAvailabilityCheck) {
+      return true;
+    }
+
+    const url =
+      this.configuration.chatHostUrl +
+      "/chat/rest/Visitor/Availability?" +
+      new URLSearchParams({
+        org_id: this.configuration.orgId,
+        deployment_id: this.configuration.deploymentId,
+        "Availability.ids": this.configuration.chatButtonId,
+      });
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "X-LIVEAGENT-API-VERSION": SALESFORCE_API_VERSION,
+      },
+    });
+
+    if (!response.ok) {
+      return true;
+    }
+
+    const data = (await response.json()) as ChatAvailabilityResponse;
+    const availabilityMessage = data?.messages?.find(
+      (message: any) => message.type === "Availability",
+    );
+    const result = availabilityMessage?.message?.results?.find(
+      (result: any) => result.id === this.configuration.chatButtonId,
+    );
+
+    if (result) {
+      return !!result.isAvailable; // undefined and false are both false
+    }
+
+    return true;
+  };
 }

--- a/lib/handoff/ZendeskStrategy.ts
+++ b/lib/handoff/ZendeskStrategy.ts
@@ -65,4 +65,5 @@ export class ZendeskStrategy implements HandoffStrategy {
 export class ZendeskServerStrategy implements ServerHandoffStrategy {
   constructor(private configuration: ZendeskHandoffConfiguration) {}
   isLiveHandoffAvailable? = () => Promise.resolve(true);
+  fetchHandoffAvailability? = () => Promise.resolve(true);
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,7 +31,8 @@
       "connect_to_live_agent": "Connect to live agent",
       "connection_to_live_agent_success_title": "You are now connecting to a live agent",
       "connection_to_live_agent_success_description": "Please wait for the agent to respond.",
-      "email_placeholder": "Email address"
+      "email_placeholder": "Email address",
+      "agents_unavailable": "No agents are currently available. Please try again later."
     },
     "Handoff": {
       "connected_to_agent": "Connected to agent",

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,7 +31,8 @@
       "connect_to_live_agent": "Conectar con un agente en vivo",
       "connection_to_live_agent_success_title": "Ahora estás conectando con un agente en vivo",
       "connection_to_live_agent_success_description": "Por favor, espera a que el agente responda.",
-      "email_placeholder": "Correo electrónico"
+      "email_placeholder": "Correo electrónico",
+      "agents_unavailable": "No hay agentes disponibles en este momento. Por favor, inténtalo de nuevo más tarde."
     },
     "Handoff": {
       "connected_to_agent": "Conectado con el agente",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -31,7 +31,8 @@
       "connect_to_live_agent": "Connecter à un agent en direct",
       "connection_to_live_agent_success_title": "Vous êtes maintenant connecté à un agent en direct",
       "connection_to_live_agent_success_description": "Veuillez attendre que l'agent réponde.",
-      "email_placeholder": "Adresse e-mail"
+      "email_placeholder": "Adresse e-mail",
+      "agents_unavailable": "Aucun agent n'est actuellement disponible. Veuillez réessayer plus tard."
     },
     "Handoff": {
       "connected_to_agent": "Connecté avec l'agent",

--- a/messages/it.json
+++ b/messages/it.json
@@ -31,7 +31,8 @@
       "connect_to_live_agent": "Connetti a un agente in diretta",
       "connection_to_live_agent_success_title": "Ora sei connesso a un agente in diretta",
       "connection_to_live_agent_success_description": "Per favore attendi che l'agente risponda.",
-      "email_placeholder": "Email"
+      "email_placeholder": "Email",
+      "agents_unavailable": "Nessun agente è attualmente disponibile. Per favore riprova più tardi."
     },
     "Handoff": {
       "connected_to_agent": "Connesso con l'agente",

--- a/packages/components/ReactMarkdown.tsx
+++ b/packages/components/ReactMarkdown.tsx
@@ -18,6 +18,7 @@ export function ReactMarkdown({
   children,
   bulletsInside = false,
   linkTargetInNewTab = true,
+  underlineLinks = false,
 }: ReactMarkdownProps) {
   // Note: list-style-position: inside does not work well on chrome if the <li> might have <p> within them
   const listStylePosition = bulletsInside ? "inside" : "outside";

--- a/packages/components/ReactMarkdown.tsx
+++ b/packages/components/ReactMarkdown.tsx
@@ -18,7 +18,6 @@ export function ReactMarkdown({
   children,
   bulletsInside = false,
   linkTargetInNewTab = true,
-  underlineLinks = false,
 }: ReactMarkdownProps) {
   // Note: list-style-position: inside does not work well on chrome if the <li> might have <p> within them
   const listStylePosition = bulletsInside ? "inside" : "outside";

--- a/packages/components/chat/EscalationFormDisplay.tsx
+++ b/packages/components/chat/EscalationFormDisplay.tsx
@@ -2,10 +2,11 @@ import { useContext } from "react";
 import { useTranslations } from "next-intl";
 import React, { useState, useEffect } from "react";
 import { IoChatbubbleEllipsesOutline } from "react-icons/io5";
+import { useParams } from "next/navigation";
+import { ReactMarkdown } from "@magi/components/ReactMarkdown";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { useSettings } from "@/app/providers/SettingsProvider";
 import { isHandoffAvailable } from "@/app/actions";
-import { useParams } from "next/navigation";
 
 import { ChatContext } from "./Chat";
 import {
@@ -49,7 +50,11 @@ function EscalationForm({ isAvailable }: { isAvailable: boolean }) {
   });
 
   if (!isAvailable) {
-    return <Alert variant="warning">{availabilityFallbackMessage}</Alert>;
+    return (
+      <Alert variant="warning" className="[&_a]:underline">
+        <ReactMarkdown>{availabilityFallbackMessage}</ReactMarkdown>
+      </Alert>
+    );
   }
 
   if (methods.formState.isSubmitSuccessful) {

--- a/packages/components/chat/EscalationFormDisplay.tsx
+++ b/packages/components/chat/EscalationFormDisplay.tsx
@@ -1,6 +1,6 @@
-import { useContext, Suspense } from "react";
+import { useContext } from "react";
 import { useTranslations } from "next-intl";
-import React, { useState, use, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { IoChatbubbleEllipsesOutline } from "react-icons/io5";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { useSettings } from "@/app/providers/SettingsProvider";

--- a/packages/components/chat/EscalationFormDisplay.tsx
+++ b/packages/components/chat/EscalationFormDisplay.tsx
@@ -23,7 +23,7 @@ async function checkHandoffAvailability(
   agentId: string,
 ) {
   const result = await isHandoffAvailable(organizationId, agentId);
-  console.log({ result });
+
   if (result.success) {
     return result.data ?? true;
   }

--- a/packages/components/chat/EscalationFormDisplay.tsx
+++ b/packages/components/chat/EscalationFormDisplay.tsx
@@ -23,11 +23,7 @@ async function checkHandoffAvailability(
   agentId: string,
 ) {
   const result = await isHandoffAvailable(organizationId, agentId);
-
-  if (result.success) {
-    return result.data ?? true;
-  }
-  return true;
+  return result ?? true;
 }
 
 function EscalationForm({ isAvailable }: { isAvailable: boolean }) {

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -55,6 +55,8 @@ declare global {
       | {
           type: HandoffConfiguration["type"];
           surveyLink?: string;
+          enableAvailabilityCheck?: boolean;
+          availabilityFallbackMessage?: string;
         }
       | undefined;
   }

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -41,6 +41,8 @@ declare global {
     allowAnonymousHandoff?: boolean;
     apiSecret: string;
     surveyLink?: string;
+    enableAvailabilityCheck?: boolean;
+    availabilityFallbackMessage?: string;
   };
 
   type HandoffConfiguration =

--- a/types/salesforce/index.ts
+++ b/types/salesforce/index.ts
@@ -1,5 +1,8 @@
 import { type Message } from "@/types";
 
+// Constants
+export const SALESFORCE_CHAT_SUBJECT_HEADER_KEY = "MAVEN-CHAT-SUBJECT";
+
 export const SALESFORCE_MESSAGE_TYPES = {
   AgentDisconnect: "AgentDisconnect",
   AgentNotTyping: "AgentNotTyping",
@@ -23,6 +26,7 @@ export const SALESFORCE_MESSAGE_TYPES_FOR_HANDOFF_TERMINATION: SalesforceMessage
     SALESFORCE_MESSAGE_TYPES.ChatEnded,
   ];
 
+// Message Types
 export type SalesforceMessageType =
   (typeof SALESFORCE_MESSAGE_TYPES)[keyof typeof SALESFORCE_MESSAGE_TYPES];
 
@@ -39,12 +43,23 @@ export type SalesforceChatMessage = {
   timestamp?: number;
 };
 
-export const isSalesforceMessage = (
-  message: any,
-): message is SalesforceChatMessage => {
-  return message.type in SALESFORCE_MESSAGE_TYPES;
+export type SalesforceChatRequestFail = SalesforceChatMessage & {
+  type: typeof SALESFORCE_MESSAGE_TYPES.ChatRequestFail;
+  message: {
+    reason: string;
+    attachedRecords: string[];
+  };
+  timestamp?: number;
 };
 
+export type SalesforceChatRequestFailUnavailable = SalesforceChatRequestFail & {
+  message: {
+    reason: "Unavailable";
+    attachedRecords: string[];
+  };
+};
+
+// Response Types
 export type ChatSessionResponse = {
   key: string;
   id: string;
@@ -60,6 +75,22 @@ export type ChatVisitorSessionResponse = {
   error?: unknown;
 };
 
+export type ChatMessageResponse = {
+  messages: SalesforceChatMessage[];
+  sequence: number;
+  offset: number;
+};
+
+export type ChatAvailabilityResponse = {
+  messages: {
+    type: "Availability";
+    message: {
+      results: { id: string; isAvailable?: boolean }[];
+    };
+  }[];
+};
+
+// Request Types
 export interface InitiateChatSessionParams {
   data: {
     name: string;
@@ -103,12 +134,7 @@ export interface SendChatMessageParams {
   };
 }
 
-export type ChatMessageResponse = {
-  messages: SalesforceChatMessage[];
-  sequence: number;
-  offset: number;
-};
-
+// User Data Types
 export type SalesforceChatUserData = {
   email: string;
   firstName: string;
@@ -152,4 +178,21 @@ export type EntityFieldMap = {
   doCreate: boolean;
 };
 
-export const SALESFORCE_CHAT_SUBJECT_HEADER_KEY = "MAVEN-CHAT-SUBJECT";
+// Type Guards
+export const isSalesforceMessage = (
+  message: any,
+): message is SalesforceChatMessage => {
+  return message.type in SALESFORCE_MESSAGE_TYPES;
+};
+
+const isChatRequestFail = (
+  message: SalesforceChatMessage,
+): message is SalesforceChatRequestFail => {
+  return message.type === SALESFORCE_MESSAGE_TYPES.ChatRequestFail;
+};
+
+export const isChatRequestFailUnavailable = (
+  message: SalesforceChatRequestFail,
+): message is SalesforceChatRequestFailUnavailable => {
+  return isChatRequestFail(message) && message.message.reason === "Unavailable";
+};


### PR DESCRIPTION
# Description
Adds availability checking for handoff functionality. When enabled, checks agent availability before displaying the handoff button.

# Changes
- Adds `isHandoffAvailable` server action to check Salesforce agent availability
- Adds availability check configuration options to handoff settings
- Updates EscalationFormDisplay to conditionally check availability before showing form
- Adds fallback message translations for when agents are unavailable
- Extracts Salesforce API version to constant

Loading state:


# Testing
- [x] Verify form shows immediately when availability check disabled
![image](https://github.com/user-attachments/assets/65685278-3d97-4794-835f-a0c5a4ab1cdc)
No POST request sent
- [x] Verify form shows/hides based on agent availability when check enabled
## Available:
![image](https://github.com/user-attachments/assets/9995cb3d-2868-4c06-8e2b-9ad6943e8eeb)
![image](https://github.com/user-attachments/assets/fc0cded9-65c6-4337-bd7b-6ca8382352a2)

## Unavailable
![image](https://github.com/user-attachments/assets/42b4e4c6-0a05-4823-9bb8-17a3100f6b2d)
![image](https://github.com/user-attachments/assets/670724b5-7886-4e2a-9c97-d409d5acabbd)

- [x] Verify fallback message shows when agents unavailable

![image](https://github.com/user-attachments/assets/ab09fca7-d74c-4282-a4ac-82012f816ab4)

- [x] Verify error handling shows form on network/API errors
![image](https://github.com/user-attachments/assets/64df9791-a63c-4e46-bee4-76360e618471)
![image](https://github.com/user-attachments/assets/49024958-192c-40ef-a0c5-03e0fb29e801)
