### PR TITLE
feat: render event message on saleforce chat request fail

### DIFF
--- a/__tests__/packages/components/chat/ChatMessage.test.tsx
+++ b/__tests__/packages/components/chat/ChatMessage.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChatMessage } from "@magi/components/chat/ChatMessage";
+import { SALESFORCE_MESSAGE_TYPES } from "@/types/salesforce";
+import type {
+  UserChatMessage,
+  SalesforceChatMessage,
+  ZendeskWebhookMessage,
+  IncomingHandoffConnectionEvent,
+  QueueUpdateMessage,
+  CombinedMessage,
+} from "@/types";
+import type { Front } from "@/types/front";
+import type { ConversationMessageResponse } from "mavenagi/api";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("ChatMessage", () => {
+  const defaultProps = {
+    mavenUserId: "test-user-id",
+  };
+
+  describe("User Messages", () => {
+    it("renders user message correctly", () => {
+      const message: UserChatMessage = {
+        type: "USER",
+        text: "Hello world",
+        timestamp: 123456789,
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    it("renders user message with attachment", () => {
+      const message: UserChatMessage = {
+        type: "USER",
+        text: "Message with image",
+        timestamp: 123456789,
+        attachments: [
+          {
+            type: "image/png",
+            content: "base64content",
+          },
+        ],
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("Message with image")).toBeInTheDocument();
+      expect(screen.getByRole("img")).toHaveAttribute(
+        "src",
+        "data:image/png;base64,base64content",
+      );
+    });
+  });
+
+  describe("Bot Messages", () => {
+    it("renders bot message correctly", () => {
+      const message: ConversationMessageResponse.Bot = {
+        type: "bot",
+        botMessageType: "BOT_RESPONSE",
+        responses: [{ type: "text", text: "Bot response" }],
+        conversationMessageId: {
+          referenceId: "msg-123",
+          type: "CONVERSATION_MESSAGE",
+          appId: "app-123",
+          organizationId: "org-123",
+          agentId: "agent-123",
+        },
+        metadata: {
+          followupQuestions: [],
+          sources: [],
+        },
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("Bot response")).toBeInTheDocument();
+    });
+  });
+
+  describe("Error Messages", () => {
+    it("renders error message correctly", () => {
+      const message: CombinedMessage = {
+        type: "ERROR",
+        text: "An error occurred",
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("An error occurred")).toBeInTheDocument();
+    });
+
+    it("renders default error message when text is empty", () => {
+      const message: CombinedMessage = {
+        type: "ERROR",
+        text: "",
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(
+        screen.getByText("An error occurred. Please try again."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Handoff Messages", () => {
+    it("renders Salesforce chat message correctly", () => {
+      const message: SalesforceChatMessage = {
+        type: "ChatMessage",
+        message: {
+          text: "Agent message",
+          name: "John Agent",
+          schedule: { responseDelayMilliseconds: 0 },
+          agentId: "agent-1",
+        },
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("Agent message")).toBeInTheDocument();
+      expect(screen.getByText("John Agent")).toBeInTheDocument();
+    });
+
+    it("renders Zendesk message correctly", () => {
+      const message: ZendeskWebhookMessage = {
+        type: "handoff-zendesk",
+        id: "msg-1",
+        createdAt: "2024-01-01T00:00:00Z",
+        payload: {
+          type: "conversation:message",
+          message: {
+            id: "msg-1",
+            author: {
+              type: "user",
+              displayName: "Jane Agent",
+              avatarUrl: "avatar.png",
+            },
+            content: {
+              type: "text",
+              text: "Zendesk message",
+            },
+            received: "2024-01-01T00:00:00Z",
+          },
+        },
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("Zendesk message")).toBeInTheDocument();
+      expect(screen.getByText("Jane Agent")).toBeInTheDocument();
+    });
+
+    it("renders Front message correctly", () => {
+      const message: Front.WebhookMessage = {
+        type: "front-agent",
+        id: "msg-1",
+        author: {
+          id: "author-1",
+          first_name: "Sarah",
+          last_name: "Agent",
+          email: "sarah@example.com",
+          username: "sagent",
+          is_admin: false,
+          is_available: true,
+          is_blocked: false,
+          _links: {
+            self: "link",
+            related: { conversations: "link" },
+          },
+        },
+        body: "Front message",
+        blurb: "Front message",
+        text: "Front message",
+        created_at: 123456789,
+        is_inbound: true,
+        draft_mode: "false",
+        error_type: null,
+        version: "1.0",
+        subject: "Subject",
+        _links: {
+          self: "link",
+          related: {
+            channels: "link",
+            comments: "link",
+            conversation: "link",
+            conversations: "link",
+            contact: "link",
+            events: "link",
+          },
+        },
+        metadata: { headers: { in_reply_to: null } },
+        recipients: [],
+        attachments: [],
+        signature: null,
+        is_draft: false,
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("Front message")).toBeInTheDocument();
+      expect(screen.getByText("Sarah Agent")).toBeInTheDocument();
+    });
+  });
+
+  describe("Handoff Event Messages", () => {
+    it("renders connecting message correctly", () => {
+      const message: IncomingHandoffConnectionEvent = {
+        type: SALESFORCE_MESSAGE_TYPES.ChatConnecting,
+        timestamp: 123456789,
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("connecting_to_agent")).toBeInTheDocument();
+    });
+
+    it("renders queue update message correctly", () => {
+      const message: QueueUpdateMessage = {
+        type: SALESFORCE_MESSAGE_TYPES.QueueUpdate,
+        timestamp: 123456789,
+        message: {
+          estimatedWaitTime: 300,
+          position: 2,
+        },
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(
+        screen.getByText("chat_queue_position_estimated_wait_time"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders chat transfer message correctly", () => {
+      const message: IncomingHandoffConnectionEvent = {
+        type: SALESFORCE_MESSAGE_TYPES.ChatTransferred,
+        timestamp: 123456789,
+        message: {
+          name: "John Agent",
+          userId: "user-1",
+          sneakPeakEnabled: false,
+          isTransferToBot: false,
+          chasitorIdleTimeout: {
+            isEnabled: false,
+            warningTime: 0,
+            timeout: 0,
+          },
+        },
+      };
+
+      render(<ChatMessage message={message} {...defaultProps} />);
+      expect(screen.getByText("chat_transferred")).toBeInTheDocument();
+    });
+  });
+});

--- a/lib/handoff/SalesforceStrategy.ts
+++ b/lib/handoff/SalesforceStrategy.ts
@@ -9,13 +9,16 @@ import type {
   Message,
   UserChatMessage,
 } from "@/types";
-import type { SalesforceChatMessage } from "@/types/salesforce";
+import {
+  type SalesforceChatMessage,
+  type SalesforceChatRequestFail,
+  isChatRequestFailUnavailable,
+} from "@/types/salesforce";
 import {
   SALESFORCE_CHAT_SUBJECT_HEADER_KEY,
   SALESFORCE_MESSAGE_TYPES,
   SALESFORCE_MESSAGE_TYPES_FOR_HANDOFF_TERMINATION,
 } from "@/types/salesforce";
-
 export class SalesforceStrategy implements HandoffStrategy<Message> {
   readonly messagesEndpoint = "/api/salesforce/messages";
   readonly conversationsEndpoint = "/api/salesforce/conversations";
@@ -45,21 +48,22 @@ export class SalesforceStrategy implements HandoffStrategy<Message> {
     );
   }
 
-  handleChatEvent(event: SalesforceChatMessage):
-    | {
-        shouldEndHandoff: true;
-        agentName?: never;
-        formattedEvent?: never;
-      }
-    | {
-        agentName: string | null;
-        formattedEvent: SalesforceChatMessage;
-      } {
+  handleChatEvent(event: SalesforceChatMessage): {
+    shouldEndHandoff: boolean;
+    agentName?: string | null;
+    formattedEvent?: SalesforceChatMessage;
+  } {
     const agentName = this.getAgentName(event);
     const shouldEndHandoff = this.shouldEndHandoff(event);
 
     if (shouldEndHandoff) {
-      return { shouldEndHandoff: true };
+      const isFailUnavailableEvent = isChatRequestFailUnavailable(
+        event as SalesforceChatRequestFail,
+      );
+
+      if (!isFailUnavailableEvent) {
+        return { shouldEndHandoff: true };
+      }
     }
 
     const formattedEvent = {
@@ -67,7 +71,7 @@ export class SalesforceStrategy implements HandoffStrategy<Message> {
       timestamp: new Date().getTime(),
     } as SalesforceChatMessage;
 
-    return { agentName, formattedEvent };
+    return { agentName, formattedEvent, shouldEndHandoff };
   }
 
   showAgentTypingIndicator(

--- a/messages/en.json
+++ b/messages/en.json
@@ -42,7 +42,8 @@
       "chat_queue_position_next": "You are next in line in the queue. Your agent will be with you shortly.",
       "chat_queue_position_in_queue": "You are in the queue. Please wait for the next available agent.",
       "chat_queue_position_estimated_wait_time": "Your estimated wait time is {estimatedWaitTime} seconds.",
-      "chat_queue_position_estimated_wait_time_singular": "Your estimated wait time is {estimatedWaitTime} second."
+      "chat_queue_position_estimated_wait_time_singular": "Your estimated wait time is {estimatedWaitTime} second.",
+      "salesforce_chat_request_fail_unavailable": "We are sorry but there are no live agents available at this time."
     },
     "IdleMessage": {
       "idle_message": "We are here to help you. Please ask a question.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -42,7 +42,8 @@
       "chat_queue_position_next": "Eres el siguiente en la cola. Tu agente estará contigo en breve.",
       "chat_queue_position_in_queue": "Estás en la cola. Por favor, espera al siguiente agente disponible.",
       "chat_queue_position_estimated_wait_time": "Tu tiempo estimado de espera es de {estimatedWaitTime} segundos.",
-      "chat_queue_position_estimated_wait_time_singular": "Tu tiempo estimado de espera es de {estimatedWaitTime} segundo."
+      "chat_queue_position_estimated_wait_time_singular": "Tu tiempo estimado de espera es de {estimatedWaitTime} segundo.",
+      "salesforce_chat_request_fail_unavailable": "Lamentamos que no haya agentes disponibles en este momento."
     },
     "IdleMessage": {
       "idle_message": "Estamos aquí para ayudarte. Por favor, haz una pregunta.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -42,7 +42,8 @@
       "chat_queue_position_next": "Vous êtes le prochain dans la file d'attente. Votre agent sera avec vous sous peu.",
       "chat_queue_position_in_queue": "Vous êtes dans la file d'attente. Veuillez attendre l'agent disponible suivant.",
       "chat_queue_position_estimated_wait_time": "Votre temps d'attente estimé est de {estimatedWaitTime} secondes.",
-      "chat_queue_position_estimated_wait_time_singular": "Votre temps d'attente estimé est de {estimatedWaitTime} seconde."
+      "chat_queue_position_estimated_wait_time_singular": "Votre temps d'attente estimé est de {estimatedWaitTime} seconde.",
+      "salesforce_chat_request_fail_unavailable": "Nous sommes désolés, mais il n'y a pas d'agents en direct disponibles pour le moment."
     },
     "IdleMessage": {
       "idle_message": "Nous sommes là pour vous aider. Veuillez poser une question.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -42,7 +42,8 @@
       "chat_queue_position_next": "Sei il prossimo in coda. Il tuo agente sarà con te a breve.",
       "chat_queue_position_in_queue": "Sei in coda. Attendi il prossimo agente disponibile.",
       "chat_queue_position_estimated_wait_time": "Il tuo tempo di attesa stimato è di {estimatedWaitTime} secondi.",
-      "chat_queue_position_estimated_wait_time_singular": "Il tuo tempo di attesa stimato è di {estimatedWaitTime} secondo."
+      "chat_queue_position_estimated_wait_time_singular": "Il tuo tempo di attesa stimato è di {estimatedWaitTime} secondo.",
+      "salesforce_chat_request_fail_unavailable": "Siamo spiacenti, ma non ci sono agenti in diretta disponibili in questo momento."
     },
     "IdleMessage": {
       "idle_message": "Siamo qui per aiutarti. Per favore fai una domanda.",

--- a/packages/components/chat/ChatMessage.tsx
+++ b/packages/components/chat/ChatMessage.tsx
@@ -106,6 +106,7 @@ function getHandoffEventMessageText(
   const messageMap = {
     ChatConnecting: () => t("connecting_to_agent"),
     ChatEstablished: () => t("connected_to_agent"),
+    ChatRequestFail: () => t("salesforce_chat_request_fail_unavailable"),
     ChatEnded: () => t("chat_has_ended"),
     ChatTransferred: (message: IncomingHandoffConnectionEvent) => {
       const agentName =
@@ -216,6 +217,7 @@ export function ChatMessage({
       case SALESFORCE_MESSAGE_TYPES.ChatConnecting:
       case SALESFORCE_MESSAGE_TYPES.ChatTransferred:
       case SALESFORCE_MESSAGE_TYPES.QueueUpdate:
+      case SALESFORCE_MESSAGE_TYPES.ChatRequestFail:
         return renderHandoffEventMessage(
           message as IncomingHandoffConnectionEvent,
         );

--- a/types/salesforce/index.ts
+++ b/types/salesforce/index.ts
@@ -39,10 +39,38 @@ export type SalesforceChatMessage = {
   timestamp?: number;
 };
 
+export type SalesforceChatRequestFail = SalesforceChatMessage & {
+  type: typeof SALESFORCE_MESSAGE_TYPES.ChatRequestFail;
+  message: {
+    reason: string;
+    attachedRecords: string[];
+  };
+  timestamp?: number;
+};
+
+export type SalesforceChatRequestFailUnavailable = SalesforceChatRequestFail & {
+  message: {
+    reason: "Unavailable";
+    attachedRecords: string[];
+  };
+};
+
 export const isSalesforceMessage = (
   message: any,
 ): message is SalesforceChatMessage => {
   return message.type in SALESFORCE_MESSAGE_TYPES;
+};
+
+const isChatRequestFail = (
+  message: SalesforceChatMessage,
+): message is SalesforceChatRequestFail => {
+  return message.type === SALESFORCE_MESSAGE_TYPES.ChatRequestFail;
+};
+
+export const isChatRequestFailUnavailable = (
+  message: SalesforceChatRequestFail,
+): message is SalesforceChatRequestFailUnavailable => {
+  return isChatRequestFail(message) && message.message.reason === "Unavailable";
 };
 
 export type ChatSessionResponse = {


### PR DESCRIPTION
# Description
Adds support for rendering event messages when a Salesforce chat request fails, particularly handling the case when no agents are available.

# Changes
- Added `SalesforceChatRequestFail` and `SalesforceChatRequestFailUnavailable` types
- Updated `SalesforceStrategy.handleChatEvent()` to handle unavailable agent scenarios
- Added translations for unavailable agent messages
- Added test coverage for chat request fail scenarios in both `SalesforceStrategy` and `ChatMessage` components

# Testing
- Added unit tests for rendering chat request fail messages
- Added tests for both available and unavailable agent scenarios

![image](https://github.com/user-attachments/assets/414af971-ae30-47d1-b706-3e2a8b89eb05)
