### PR TITLE
feat: add property for custom widget button label

### DIFF
--- a/app/demo/[organizationId]/[agentId]/Widget.tsx
+++ b/app/demo/[organizationId]/[agentId]/Widget.tsx
@@ -5,6 +5,7 @@ type WidgetLoadPayload = {
   organizationId: string;
   agentId: string;
   bgColor?: string;
+  buttonLabel?: string;
   signedUserData?: string;
   unsignedUserData?: Record<string, any>;
   customData?: Record<string, any>;

--- a/packages/widget/src/chat/components/ChatButton.tsx
+++ b/packages/widget/src/chat/components/ChatButton.tsx
@@ -4,6 +4,7 @@ import { CloseIcon } from "./icons/CloseIcon";
 interface ChatButtonProps {
   bgColor: string;
   textColor: string;
+  buttonLabel: string;
   horizontalPosition: "left" | "right";
   verticalPosition: "top" | "bottom";
   isOpen: boolean;
@@ -13,6 +14,7 @@ interface ChatButtonProps {
 export function ChatButton({
   bgColor,
   textColor,
+  buttonLabel,
   horizontalPosition,
   verticalPosition,
   isOpen,
@@ -51,7 +53,7 @@ export function ChatButton({
         <div style={{ display: "flex", alignItems: "center" }}>
           <HelpIcon />
           <span style={{ marginLeft: "0.5rem", marginRight: "0.25rem" }}>
-            Get Help
+            {buttonLabel}
           </span>
         </div>
       ) : (

--- a/packages/widget/src/chat/index.tsx
+++ b/packages/widget/src/chat/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   iframeUrl: string;
   bgColor: string;
   textColor: string;
+  buttonLabel: string;
   horizontalPosition: "left" | "right";
   verticalPosition: "top" | "bottom";
   signedUserData?: string | null;
@@ -54,6 +55,7 @@ const App = forwardRef<{ open: () => void; close: () => void }, Props>(
         <ChatButton
           bgColor={props.bgColor}
           textColor={props.textColor}
+          buttonLabel={props.buttonLabel}
           horizontalPosition={props.horizontalPosition}
           verticalPosition={props.verticalPosition}
           isOpen={isOpen}
@@ -83,8 +85,15 @@ export function close() {
 type LoadProps = Partial<Omit<Props, "iframeUrl">> & {
   envPrefix?: string;
   apiKey: string;
-} & // This union type ensures backwards compatibility during the migration from the
-  // "orgFriendlyId" and "agentFriendlyId" to "organizationId" and "agentId".
+  buttonLabel?: string;
+  unsignedUserData?: Record<string, any> | null;
+  signedUserData?: string | null;
+  customData?: Record<string, any> | null;
+  verticalPosition?: "top" | "bottom";
+  horizontalPosition?: "left" | "right";
+  bgColor?: string;
+  textColor?: string;
+} & // "orgFriendlyId" and "agentFriendlyId" to "organizationId" and "agentId". // This union type ensures backwards compatibility during the migration from the
   // It enforces that either:
   // 1. Both organizationId and agentId are provided (new spec) OR
   // 2. Both orgFriendlyId and agentFriendlyId are provided (legacy spec)
@@ -107,6 +116,7 @@ export async function load({
   envPrefix: _envPrefix,
   bgColor,
   textColor = "white",
+  buttonLabel = "Get Help",
   horizontalPosition = "right",
   verticalPosition = "bottom",
   organizationId,
@@ -127,6 +137,7 @@ export async function load({
       ref={appRef}
       bgColor={bgColor || "#6C2BD9"}
       textColor={textColor}
+      buttonLabel={buttonLabel}
       horizontalPosition={horizontalPosition}
       verticalPosition={verticalPosition}
       signedUserData={signedUserData}


### PR DESCRIPTION
## Changes
- Added `buttonLabel` property to widget configuration to allow customization of the chat button text
- Default value remains "Get Help" for backwards compatibility
- Propagated the button label property through the widget component

## Technical Details
- Added `buttonLabel` to `WidgetLoadPayload` type in Widget.tsx
- Extended `ChatButtonProps` interface to include `buttonLabel` property
- Modified `load()` function to accept optional `buttonLabel` parameter
- Updated chat button component to render custom label instead of hardcoded text

## Testing
- Existing functionality remains unchanged when no button label is provided
- Custom labels are properly displayed when specified in widget configuration
![image](https://github.com/user-attachments/assets/797149be-4a06-416c-bcb2-092c5fd7d16c)
![image](https://github.com/user-attachments/assets/afa491d9-a574-4533-a1c5-cda86217a1e8)


## Migration
No breaking changes - existing implementations will continue to show "Get Help" by default