### PR TITLE
feature: introduce handoff message stream keepalive

### DIFF
--- a/app/api/salesforce/messages/route.ts
+++ b/app/api/salesforce/messages/route.ts
@@ -58,11 +58,15 @@ async function handleMessageStreaming(
         if (keepaliveInterval) {
           clearInterval(keepaliveInterval);
         }
-        keepaliveInterval = setInterval(() => {
-          if (!req.signal.aborted) {
-            controller.enqueue(KEEPALIVE_MESSAGE);
-          }
-        }, KEEPALIVE_INTERVAL);
+        if (!req.signal.aborted) {
+          keepaliveInterval = setInterval(() => {
+            if (!req.signal.aborted) {
+              controller.enqueue(KEEPALIVE_MESSAGE);
+            } else {
+              clearInterval(keepaliveInterval);
+            }
+          }, KEEPALIVE_INTERVAL);
+        }
       };
 
       try {
@@ -199,7 +203,7 @@ export async function POST(req: NextRequest) {
         return NextResponse.json("Chat message sent");
       } catch (error: any) {
         console.error(
-          "Failed to get chat messages:",
+          "Failed to send chat messages:",
           error?.message,
           error?.stack,
         );

--- a/app/api/salesforce/messages/route.ts
+++ b/app/api/salesforce/messages/route.ts
@@ -58,15 +58,11 @@ async function handleMessageStreaming(
         if (keepaliveInterval) {
           clearInterval(keepaliveInterval);
         }
-        if (!req.signal.aborted) {
-          keepaliveInterval = setInterval(() => {
-            if (!req.signal.aborted) {
-              controller.enqueue(KEEPALIVE_MESSAGE);
-            } else {
-              clearInterval(keepaliveInterval);
-            }
-          }, KEEPALIVE_INTERVAL);
-        }
+        keepaliveInterval = setInterval(() => {
+          if (!req.signal.aborted) {
+            controller.enqueue(KEEPALIVE_MESSAGE);
+          }
+        }, KEEPALIVE_INTERVAL);
       };
 
       try {


### PR DESCRIPTION
# Keepalive Messages for Salesforce Chat Stream

## Changes
- Added keepalive mechanism to maintain Salesforce chat connection
- Sends minimal SSE keepalive message every 10 seconds
- Resets keepalive timer after sending chat messages
- Cleans up interval on stream close

## Tests
- Added test suite for keepalive functionality
- Tests keepalive messages on idle connection
- Tests timer reset on message receipt
- Tests cleanup on stream end