### PR TITLE
APP-245: fix typo in event.type

### DIFF
--- a/lib/handoff/FrontStrategy.ts
+++ b/lib/handoff/FrontStrategy.ts
@@ -41,7 +41,7 @@ export class FrontStrategy implements HandoffStrategy {
   }
 
   handleChatEvent(event: Front.WebhookMessage) {
-    const isAutoReply = event.type === "message_autoreply";
+    const isAutoReply = event.type === "auto_reply";
     const agentName = isAutoReply
       ? undefined
       : `${event.author.first_name} ${event.author.last_name}`.trim();


### PR DESCRIPTION
```json
{
  "message": {
    "type": "auto_reply",
    ...
  },
  "channel": "front:monarch:rodan:vF8l1vg8uxD3ZhpAgaYsB:message"
}
```