### PR TITLE
fix: trim all string form inputs

### DIFF
--- a/packages/components/chat/BailoutFormDisplay.tsx
+++ b/packages/components/chat/BailoutFormDisplay.tsx
@@ -21,6 +21,11 @@ export default function BailoutFormDisplay({
       formData.append("organizationId", organizationId as string);
       formData.append("agentId", agentId as string);
       formData.append("conversationId", conversationId as string);
+
+      formData.forEach((value, key) => {
+        formData.set(key, typeof value === "string" ? value.trim() : value);
+      });
+
       return await submitBailoutForm(null, formData);
     },
     [organizationId, agentId, conversationId, action.id],


### PR DESCRIPTION
Seeing some errors related to emails failing validation due to extra spaces

`Email address ckubacak@granger.txed.net  is invalid`

https://us3.datadoghq.com/logs?query=source%3Avercel%20-status%3A%28warn%20OR%20notice%20OR%20info%20OR%20ok%29&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZTSPLKw76la2wAAABhBWlRTUE1lQ0FBQTVFbFpMR0xfY2dnQUUAAAAkMDE5NGQyNDgtYzYzZi00YjU1LWI4NGUtNGFjODFhNDI4NDA0AAYhKQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=17295&storage=hot&stream_sort=desc&viz=stream&from_ts=1738681770454&to_ts=1738696170454&live=true

