### PR TITLE
fix: correct typo in settings adapter

### DIFF
--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -166,7 +166,7 @@ describe("getPublicAppSettings", () => {
             brandColor: "#000",
           },
           security: {
-            embedAllowList: ["domain.com"],
+            embedAllowlist: ["domain.com"],
           },
           misc: {
             amplitudeApiKey: "test-key",
@@ -194,7 +194,7 @@ describe("getPublicAppSettings", () => {
         brandColor: "#000",
       },
       security: {
-        embedAllowList: ["domain.com"],
+        embedAllowlist: ["domain.com"],
       },
       misc: {
         amplitudeApiKey: "test-key",

--- a/__tests__/lib/settings.test.ts
+++ b/__tests__/lib/settings.test.ts
@@ -34,7 +34,7 @@ describe("adaptLegacySettings", () => {
       },
       security: {
         jwtPublicKey: "legacy-jwt",
-        embedAllowList: ["legacy-domain"],
+        embedAllowlist: ["legacy-domain"],
         encryptionSecret: "legacy-secret",
       },
       misc: {
@@ -88,7 +88,7 @@ describe("adaptLegacySettings", () => {
       },
       security: {
         jwtPublicKey: undefined,
-        embedAllowList: undefined,
+        embedAllowlist: undefined,
         encryptionSecret: undefined,
       },
       misc: {
@@ -119,7 +119,7 @@ describe("adaptLegacySettings", () => {
       },
       security: {
         jwtPublicKey: undefined,
-        embedAllowList: undefined,
+        embedAllowlist: undefined,
         encryptionSecret: undefined,
       },
       misc: {

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -6,7 +6,7 @@ import { getAppSettings } from "@/app/api/server/utils";
 vi.mock("@/app/api/server/utils", () => ({
   getAppSettings: vi.fn().mockResolvedValue({
     security: {
-      embedAllowList: [],
+      embedAllowlist: [],
     },
     branding: {
       enableDemoSite: "false",
@@ -136,7 +136,7 @@ describe("Middleware", () => {
           beforeEach(() => {
             (getAppSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
               security: {
-                embedAllowList: ["allowed-domain.com"],
+                embedAllowlist: ["allowed-domain.com"],
               },
               branding: {
                 enableDemoSite: "false",

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -128,7 +128,7 @@ export async function getPublicAppSettings(
     return {
       branding: settings.branding,
       security: {
-        embedAllowList: settings.security?.embedAllowList,
+        embedAllowlist: settings.security?.embedAllowlist,
       },
       misc: {
         amplitudeApiKey: settings.misc?.amplitudeApiKey,

--- a/app/api/server/utils.ts
+++ b/app/api/server/utils.ts
@@ -29,6 +29,7 @@ export async function getAppSettings(
   const client = getMavenAGIClient(organizationId, agentId);
   const legacySettings =
     (await client.appSettings.get()) as unknown as InterimAppSettings;
+  console.log("legacySettings", legacySettings);
   const settings = adaptLegacySettings(legacySettings);
 
   if (settings.misc?.handoffConfiguration) {

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -24,8 +24,8 @@ export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
   // Set security properties
   adapted.security = {
     jwtPublicKey: settings.security?.jwtPublicKey ?? settings.jwtPublicKey,
-    embedAllowList:
-      settings.security?.embedAllowList ?? settings.embedAllowlist,
+    embedAllowlist:
+      settings.security?.embedAllowlist ?? settings.embedAllowlist,
     encryptionSecret:
       settings.security?.encryptionSecret ?? settings.encryptionSecret,
   };

--- a/middleware.ts
+++ b/middleware.ts
@@ -58,7 +58,7 @@ const processSecuritySettings = (
   appSettings: ParsedAppSettings,
   request: NextRequest,
 ): { headers?: string; blocked: boolean } => {
-  const allowlist = [...(appSettings.security.embedAllowList || [])];
+  const allowlist = [...(appSettings.security.embedAllowlist || [])];
   const enableDemoSite = ["true", "1"].includes(
     appSettings.branding.enableDemoSite || "",
   );
@@ -103,6 +103,7 @@ export async function middleware(request: NextRequest) {
 
     try {
       const appSettings = await getAppSettings(organizationId, agentId);
+      console.log("appSettings", appSettings);
       const security = processSecuritySettings(appSettings, request);
       const ENABLE_CSP_LOGGING = process.env.ENABLE_CSP_LOGGING === "true";
       const ORGANIZATIONS_WITH_CSP_DISABLED =
@@ -131,7 +132,7 @@ export async function middleware(request: NextRequest) {
             secFetchMode: request.headers.get("sec-fetch-mode"),
             isAllowedDomain: isAllowedDomain(
               request.headers.get("referer"),
-              appSettings.security.embedAllowList || [],
+              appSettings.security.embedAllowlist || [],
             ),
           });
         }

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -26,7 +26,7 @@ declare global {
     };
     security: {
       jwtPublicKey?: string;
-      embedAllowList?: string[];
+      embedAllowlist?: string[];
       encryptionSecret?: string;
     };
     misc: {
@@ -92,7 +92,7 @@ declare global {
   interface ClientSafeAppSettings {
     branding: AppSettings["branding"];
     security: {
-      embedAllowList?: AppSettings["security"]["embedAllowList"];
+      embedAllowlist?: AppSettings["security"]["embedAllowlist"];
     };
     misc: {
       amplitudeApiKey?: AppSettings["misc"]["amplitudeApiKey"];


### PR DESCRIPTION
## Changes
- Fixed typo in settings adapter property name from `embedAllowList` to `embedAllowlist`

## Impact
- Maintains backward compatibility with existing settings
- Ensures consistent property naming throughout the codebase