### PR TITLE
feat: add disable-redirect search param to demo

### DIFF
--- a/__tests__/app/[organizationId]/[agentId]/page.test.tsx
+++ b/__tests__/app/[organizationId]/[agentId]/page.test.tsx
@@ -11,7 +11,6 @@ import { HandoffStatus } from "@/app/constants/handoff";
 import { useChat } from "@magi/components/chat/use-chat";
 import { useHandoff } from "@/lib/useHandoff";
 import { useScrollToBottom } from "@/lib/useScrollToBottom";
-import { useIdleMessage } from "@/lib/useIdleMessage";
 
 let chatMessages = [] as Message[];
 let handoffMessages = [] as (
@@ -35,6 +34,8 @@ vi.mock("@/lib/useIframeMessaging", () => ({
   useIframeMessaging: () => ({
     loading: false,
     signedUserData: null,
+    unsignedUserData: null,
+    customData: null,
   }),
 }));
 
@@ -61,6 +62,7 @@ describe("ChatPage", () => {
       addMessage: vi.fn(),
       conversationId: "test-conversation-id",
       mavenUserId: "test-maven-user-id",
+      onBailoutFormSubmitSuccess: vi.fn(),
     });
 
     useHandoffMock.mockReturnValue({

--- a/__tests__/lib/useIframeMessaging.test.ts
+++ b/__tests__/lib/useIframeMessaging.test.ts
@@ -1,0 +1,183 @@
+import { renderHook, act } from "@testing-library/react";
+import {
+  describe,
+  expect,
+  test,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import { useIframeMessaging } from "@/lib/useIframeMessaging";
+
+// Mock search params value for testing
+let mockDisableRedirectValue: string | null = null;
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({
+    organizationId: "test-org",
+    agentId: "test-agent",
+  }),
+  useSearchParams: () => ({
+    get: (key: string) =>
+      key === "disableRedirect" ? mockDisableRedirectValue : null,
+  }),
+}));
+
+describe("useIframeMessaging", () => {
+  const originalWindow = global.window;
+  let mockPostMessage: Mock;
+
+  const createMockWindow = (isIframe = false) => {
+    const mockWindow = {
+      ...originalWindow,
+      parent: {
+        postMessage: mockPostMessage,
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      location: {
+        href: "",
+      },
+    };
+
+    if (isIframe) {
+      // For iframe environment, self and top should be different objects
+      Object.defineProperty(mockWindow, "self", {
+        value: {},
+        writable: true,
+      });
+      Object.defineProperty(mockWindow, "top", {
+        value: { some: "other-value" },
+        writable: true,
+      });
+    } else {
+      // For non-iframe environment, self and top should reference the same object
+      Object.defineProperty(mockWindow, "self", {
+        value: mockWindow,
+        writable: true,
+      });
+      Object.defineProperty(mockWindow, "top", {
+        value: mockWindow,
+        writable: true,
+      });
+    }
+
+    return mockWindow;
+  };
+
+  const setupWindow = (isIframe = false) => {
+    Object.defineProperty(global, "window", {
+      value: createMockWindow(isIframe),
+      writable: true,
+    });
+  };
+
+  beforeEach(() => {
+    mockPostMessage = vi.fn();
+    mockDisableRedirectValue = null;
+    setupWindow();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, "window", {
+      value: originalWindow,
+      writable: true,
+    });
+    vi.clearAllMocks();
+  });
+
+  describe("disableRedirect behavior", () => {
+    const testCases = [
+      { param: "true", expected: true, description: "param is 'true'" },
+      { param: "", expected: true, description: "param is empty string" },
+      {
+        param: "anything",
+        expected: true,
+        description: "param is any non-false value",
+      },
+      { param: null, expected: false, description: "param is not present" },
+      { param: "false", expected: false, description: "param is 'false'" },
+    ];
+
+    testCases.forEach(({ param, expected, description }) => {
+      test(`should handle disableRedirect when ${description}`, () => {
+        mockDisableRedirectValue = param;
+        renderHook(() => useIframeMessaging());
+
+        if (expected) {
+          expect(window.location.href).toBe("/demo/test-org/test-agent");
+        } else {
+          expect(window.location.href).not.toBe("");
+        }
+      });
+    });
+  });
+
+  describe("message handling", () => {
+    beforeEach(() => {
+      setupWindow(true);
+    });
+
+    const messageTypes = [
+      {
+        type: "SIGNED_USER_DATA",
+        data: "test-signed-data",
+        resultKey: "signedUserData" as const,
+        expected: "test-signed-data",
+      },
+      {
+        type: "UNSIGNED_USER_DATA",
+        data: { id: "test-id" },
+        resultKey: "unsignedUserData" as const,
+        expected: { id: "test-id" },
+      },
+      {
+        type: "CUSTOM_DATA",
+        data: { custom: "data" },
+        resultKey: "customData" as const,
+        expected: { custom: "data" },
+      },
+    ];
+
+    messageTypes.forEach(({ type, data, resultKey, expected }) => {
+      test(`should handle ${type} message`, () => {
+        const { result } = renderHook(() => useIframeMessaging());
+
+        const mockMessageEvent = { data: { type, data } };
+
+        const addEventListener = vi.mocked(window.addEventListener);
+        expect(addEventListener).toHaveBeenCalledWith(
+          "message",
+          expect.any(Function),
+        );
+        const messageHandler = addEventListener.mock.calls[0][1] as Function;
+
+        act(() => {
+          messageHandler(mockMessageEvent);
+        });
+
+        expect(result.current[resultKey]).toEqual(expected);
+      });
+    });
+  });
+
+  test("should cleanup event listener on unmount", () => {
+    setupWindow(true);
+    const { unmount } = renderHook(() => useIframeMessaging());
+
+    const addEventListener = vi.mocked(window.addEventListener);
+    expect(addEventListener).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function),
+    );
+    const messageHandler = addEventListener.mock.calls[0][1];
+
+    unmount();
+
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      "message",
+      messageHandler,
+    );
+  });
+});

--- a/app/[organizationId]/[agentId]/page.tsx
+++ b/app/[organizationId]/[agentId]/page.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useEffect, useMemo } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import Chat from "@magi/components/chat/Chat";
 import { ChatInput } from "@magi/components/chat/ChatInput";
 import { useChat } from "@magi/components/chat/use-chat";
@@ -138,8 +138,12 @@ function ChatPage() {
 }
 
 export default function ChatPageWrapper() {
+  const searchParams = useSearchParams();
+  const disableRedirectParam = searchParams.get("disableRedirect");
+  const disableRedirect =
+    disableRedirectParam !== null && disableRedirectParam !== "false";
   const { loading, signedUserData, unsignedUserData, customData } =
-    useIframeMessaging();
+    useIframeMessaging({ disableRedirect });
 
   if (loading) return null;
 

--- a/lib/useIframeMessaging.ts
+++ b/lib/useIframeMessaging.ts
@@ -15,7 +15,8 @@ enum MAVEN_MESSAGE_TYPES {
 const demoUrl = (organizationId: string, agentId: string) =>
   `/demo/${organizationId}/${agentId}`;
 
-export function useIframeMessaging() {
+export function useIframeMessaging(options?: { disableRedirect?: boolean }) {
+  const { disableRedirect = false } = options || {};
   const [loading, setLoading] = useState(true);
   const [signedUserData, setSignedUserData] = useState<string | null>(null);
   const [unsignedUserData, setUnsignedUserData] = useState<Record<
@@ -60,7 +61,7 @@ export function useIframeMessaging() {
       }
     };
 
-    if (!isInIframe()) {
+    if (!disableRedirect && !isInIframe()) {
       window.location.href = demoUrl(organizationId, agentId);
       return;
     }
@@ -75,7 +76,7 @@ export function useIframeMessaging() {
     }
 
     return () => window.removeEventListener("message", handleMessage);
-  }, [organizationId, agentId, handleMessage]);
+  }, [organizationId, agentId, handleMessage, disableRedirect]);
 
   return {
     loading,


### PR DESCRIPTION
# Add disable-redirect search param to demo

## Description
Adds the ability to disable automatic redirection to the demo page using a URL search parameter. This enhancement provides more flexibility in how the chat interface behaves when not in an iframe context.

## Changes
- Added `disableRedirect` parameter to `useIframeMessaging` hook
- Updated redirection logic to respect the `disableRedirect` parameter