### PR TITLE
fix(widget): safely extend Maven global object

### DIFF
--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -13,7 +13,8 @@ declare global {
   }
 }
 
-window.Maven = window.Maven || {
+window.Maven = {
+  ...(window.Maven || {}),
   ChatWidget,
 };
 


### PR DESCRIPTION
# Changes
- Chat widget extends `window.Maven` on load
- Preserves any existing Maven submodules, (e.g. instant answers)