### PR TITLE
feat: add manual locale and idle message support

### DIFF
--- a/__tests__/app/[organizationId]/[agentId]/page.test.tsx
+++ b/__tests__/app/[organizationId]/[agentId]/page.test.tsx
@@ -1,19 +1,29 @@
+// External packages
 import { render, screen } from "@testing-library/react";
-import ChatPage from "@/app/[organizationId]/[agentId]/page";
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
-import {
+
+// Types
+import type {
   IncomingHandoffConnectionEvent,
   Message,
   UserChatMessage,
   IncomingHandoffEvent,
 } from "@/types";
+
+// Constants
 import { HandoffStatus } from "@/app/constants/handoff";
+
+// Hooks
 import { useChat } from "@magi/components/chat/use-chat";
 import { useHandoff } from "@/lib/useHandoff";
 import { useScrollToBottom } from "@/lib/useScrollToBottom";
 import { useSettings } from "@/app/providers/SettingsProvider";
 import { useIdleMessage } from "@/lib/useIdleMessage";
 
+// Components
+import ChatPage from "@/app/[organizationId]/[agentId]/page";
+
+// Test setup
 let chatMessages = [] as Message[];
 let handoffMessages = [] as (
   | IncomingHandoffEvent
@@ -21,6 +31,7 @@ let handoffMessages = [] as (
   | IncomingHandoffConnectionEvent
 )[];
 
+// Mocks
 vi.mock("@/lib/useScrollToBottom");
 const useScrollToBottomMock = vi.mocked(useScrollToBottom);
 
@@ -52,127 +63,24 @@ vi.mock("@/lib/useAskQuestion", () => ({
   }),
 }));
 
-describe("ChatPage", () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
+describe("ChatPage Component", () => {
+  describe("Component Integration", () => {
+    beforeEach(async () => {
+      vi.clearAllMocks();
 
-    useScrollToBottomMock.mockReturnValue([
-      { current: null },
-      { current: null },
-    ] as const);
-
-    useChatMock.mockReturnValue({
-      messages: chatMessages,
-      isLoading: false,
-      isResponseAvailable: false,
-      addMessage: vi.fn(),
-      conversationId: "test-conversation-id",
-      mavenUserId: "test-maven-user-id",
-      onBailoutFormSubmitSuccess: vi.fn(),
-    });
-
-    useHandoffMock.mockReturnValue({
-      ...useHandoffMock({
-        messages: chatMessages,
-        mavenConversationId: "test-maven-conversation-id",
-      }),
-      handoffChatEvents: handoffMessages,
-      initializeHandoff: vi.fn(),
-      agentName: "Lenny",
-      handoffStatus: HandoffStatus.INITIALIZED,
-      askHandoff: vi.fn(),
-      handleEndHandoff: vi.fn(),
-    });
-
-    useSettingsMock.mockReturnValue({
-      branding: {},
-      misc: {
-        enableIdleMessage: true,
-        handoffConfiguration: {
-          type: "salesforce",
-          enableAvailabilityCheck: true,
-          allowAnonymousHandoff: false,
-        },
-      },
-      security: {},
-    });
-  });
-
-  afterEach(() => {
-    [chatMessages, handoffMessages] = [[], []];
-    vi.restoreAllMocks();
-  });
-
-  describe("idle message setup", () => {
-    test("should always call useIdleMessage with correct props", () => {
-      render(<ChatPage />);
-
-      expect(useIdleMessageMock).toHaveBeenCalledWith({
-        messages: chatMessages,
-        conversationId: "test-conversation-id",
-        agentName: "Lenny",
-        addMessage: expect.any(Function),
-      });
-    });
-  });
-
-  describe("when there are no messages", () => {
-    test("should render ChatPage with correct initial structure", async () => {
-      render(<ChatPage />);
-
-      await screen.findByRole("main");
-
-      expect(screen.getByRole("banner")).toBeInTheDocument(); // ChatHeader
-      expect(screen.getByRole("main")).toBeInTheDocument();
-      expect(screen.getByTestId("chat-input")).toBeInTheDocument();
-      expect(screen.getAllByTestId("chat-bubble")).toHaveLength(1); // Welcome message chat bubble
-      expect(screen.getByText("Powered by")).toBeInTheDocument(); // Only when there are no messages
-    });
-  });
-
-  describe("when there are messages", () => {
-    beforeEach(() => {
-      chatMessages = [
-        { timestamp: 100, text: "First message", type: "USER" },
-        { timestamp: 300, text: "Third message", type: "USER" },
-      ];
-
-      handoffMessages = [
-        {
-          timestamp: 200,
-          createdAt: "2024-01-01",
-          id: "1",
-          type: "handoff-zendesk",
-          payload: {
-            message: {
-              id: "1",
-              author: { type: "user", displayName: "Lenny" },
-              content: { type: "text", text: "Second message" },
-              received: "2024-01-01",
-            },
-            type: "conversation:message",
-          },
-        },
-        {
-          timestamp: 400,
-          createdAt: "2024-01-01",
-          id: "2",
-          type: "handoff-zendesk",
-          payload: {
-            message: {
-              id: "2",
-              author: { type: "user", displayName: "Lenny" },
-              content: { type: "text", text: "Fourth message" },
-              received: "2024-01-01",
-            },
-            type: "conversation:message",
-          },
-        },
-      ];
+      useScrollToBottomMock.mockReturnValue([
+        { current: null },
+        { current: null },
+      ] as const);
 
       useChatMock.mockReturnValue({
-        ...useChatMock(),
         messages: chatMessages,
+        isLoading: false,
+        isResponseAvailable: false,
+        addMessage: vi.fn(),
+        conversationId: "test-conversation-id",
+        mavenUserId: "test-maven-user-id",
+        onBailoutFormSubmitSuccess: vi.fn(),
       });
 
       useHandoffMock.mockReturnValue({
@@ -181,33 +89,136 @@ describe("ChatPage", () => {
           mavenConversationId: "test-maven-conversation-id",
         }),
         handoffChatEvents: handoffMessages,
+        initializeHandoff: vi.fn(),
+        agentName: "Lenny",
+        handoffStatus: HandoffStatus.INITIALIZED,
+        askHandoff: vi.fn(),
+        handleEndHandoff: vi.fn(),
+      });
+
+      useSettingsMock.mockReturnValue({
+        branding: {},
+        misc: {
+          enableIdleMessage: true,
+          handoffConfiguration: {
+            type: "salesforce",
+            enableAvailabilityCheck: true,
+            allowAnonymousHandoff: false,
+          },
+        },
+        security: {},
       });
     });
 
-    test("should render ChatPage with correct initial structure", async () => {
-      render(<ChatPage />);
-
-      await screen.findByRole("main");
-
-      expect(screen.queryByText("Powered by")).not.toBeInTheDocument();
+    afterEach(() => {
+      [chatMessages, handoffMessages] = [[], []];
+      vi.restoreAllMocks();
     });
 
-    describe("message combining logic", () => {
-      test("should combine and sort messages correctly", async () => {
+    describe("idle message integration", () => {
+      test("should initialize idle message hook with correct configuration", () => {
+        render(<ChatPage />);
+
+        expect(useIdleMessageMock).toHaveBeenCalledWith({
+          messages: chatMessages,
+          conversationId: "test-conversation-id",
+          agentName: "Lenny",
+          addMessage: expect.any(Function),
+        });
+      });
+    });
+
+    describe("initial render", () => {
+      test("should display welcome message and core UI elements when no messages exist", async () => {
         render(<ChatPage />);
 
         await screen.findByRole("main");
 
-        const getAllChatBubbles = screen.getAllByTestId("chat-bubble");
-        expect(getAllChatBubbles).toHaveLength(5);
-        [
-          "default_welcome_message",
-          "First message",
-          "Second message",
-          "Third message",
-          "Fourth message",
-        ].forEach((text, index) => {
-          expect(getAllChatBubbles[index]).toHaveTextContent(text);
+        expect(screen.getByRole("banner")).toBeInTheDocument(); // ChatHeader
+        expect(screen.getByRole("main")).toBeInTheDocument();
+        expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+        expect(screen.getAllByTestId("chat-bubble")).toHaveLength(1); // Welcome message chat bubble
+        expect(screen.getByText("Powered by")).toBeInTheDocument(); // Only when there are no messages
+      });
+    });
+
+    describe("message handling", () => {
+      beforeEach(() => {
+        chatMessages = [
+          { timestamp: 100, text: "First message", type: "USER" },
+          { timestamp: 300, text: "Third message", type: "USER" },
+        ];
+
+        handoffMessages = [
+          {
+            timestamp: 200,
+            createdAt: "2024-01-01",
+            id: "1",
+            type: "handoff-zendesk",
+            payload: {
+              message: {
+                id: "1",
+                author: { type: "user", displayName: "Lenny" },
+                content: { type: "text", text: "Second message" },
+                received: "2024-01-01",
+              },
+              type: "conversation:message",
+            },
+          },
+          {
+            timestamp: 400,
+            createdAt: "2024-01-01",
+            id: "2",
+            type: "handoff-zendesk",
+            payload: {
+              message: {
+                id: "2",
+                author: { type: "user", displayName: "Lenny" },
+                content: { type: "text", text: "Fourth message" },
+                received: "2024-01-01",
+              },
+              type: "conversation:message",
+            },
+          },
+        ];
+
+        useChatMock.mockReturnValue({
+          ...useChatMock(),
+          messages: chatMessages,
+        });
+
+        useHandoffMock.mockReturnValue({
+          ...useHandoffMock({
+            messages: chatMessages,
+            mavenConversationId: "test-maven-conversation-id",
+          }),
+          handoffChatEvents: handoffMessages,
+        });
+      });
+
+      test("should hide powered by text when messages exist", async () => {
+        render(<ChatPage />);
+        await screen.findByRole("main");
+        expect(screen.queryByText("Powered by")).not.toBeInTheDocument();
+      });
+
+      describe("message ordering", () => {
+        test("should display messages in chronological order with welcome message first", async () => {
+          render(<ChatPage />);
+
+          await screen.findByRole("main");
+
+          const getAllChatBubbles = screen.getAllByTestId("chat-bubble");
+          expect(getAllChatBubbles).toHaveLength(5);
+          [
+            "default_welcome_message",
+            "First message",
+            "Second message",
+            "Third message",
+            "Fourth message",
+          ].forEach((text, index) => {
+            expect(getAllChatBubbles[index]).toHaveTextContent(text);
+          });
         });
       });
     });

--- a/__tests__/app/[organizationId]/[agentId]/page.test.tsx
+++ b/__tests__/app/[organizationId]/[agentId]/page.test.tsx
@@ -11,6 +11,8 @@ import { HandoffStatus } from "@/app/constants/handoff";
 import { useChat } from "@magi/components/chat/use-chat";
 import { useHandoff } from "@/lib/useHandoff";
 import { useScrollToBottom } from "@/lib/useScrollToBottom";
+import { useSettings } from "@/app/providers/SettingsProvider";
+import { useIdleMessage } from "@/lib/useIdleMessage";
 
 let chatMessages = [] as Message[];
 let handoffMessages = [] as (
@@ -29,6 +31,10 @@ vi.mock("@/lib/useHandoff");
 const useHandoffMock = vi.mocked(useHandoff);
 
 vi.mock("@/lib/useIdleMessage");
+const useIdleMessageMock = vi.mocked(useIdleMessage);
+
+vi.mock("@/app/providers/SettingsProvider");
+const useSettingsMock = vi.mocked(useSettings);
 
 vi.mock("@/lib/useIframeMessaging", () => ({
   useIframeMessaging: () => ({
@@ -77,11 +83,37 @@ describe("ChatPage", () => {
       askHandoff: vi.fn(),
       handleEndHandoff: vi.fn(),
     });
+
+    useSettingsMock.mockReturnValue({
+      branding: {},
+      misc: {
+        enableIdleMessage: true,
+        handoffConfiguration: {
+          type: "salesforce",
+          enableAvailabilityCheck: true,
+          allowAnonymousHandoff: false,
+        },
+      },
+      security: {},
+    });
   });
 
   afterEach(() => {
     [chatMessages, handoffMessages] = [[], []];
     vi.restoreAllMocks();
+  });
+
+  describe("idle message setup", () => {
+    test("should always call useIdleMessage with correct props", () => {
+      render(<ChatPage />);
+
+      expect(useIdleMessageMock).toHaveBeenCalledWith({
+        messages: chatMessages,
+        conversationId: "test-conversation-id",
+        agentName: "Lenny",
+        addMessage: expect.any(Function),
+      });
+    });
   });
 
   describe("when there are no messages", () => {

--- a/__tests__/app/[organizationId]/[agentId]/page.test.tsx
+++ b/__tests__/app/[organizationId]/[agentId]/page.test.tsx
@@ -99,7 +99,7 @@ describe("ChatPage Component", () => {
       useSettingsMock.mockReturnValue({
         branding: {},
         misc: {
-          enableIdleMessage: true,
+          idleMessageTimeout: 10,
           handoffConfiguration: {
             type: "salesforce",
             enableAvailabilityCheck: true,
@@ -124,6 +124,7 @@ describe("ChatPage Component", () => {
           conversationId: "test-conversation-id",
           agentName: "Lenny",
           addMessage: expect.any(Function),
+          isHandoff: true,
         });
       });
     });

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -171,6 +171,7 @@ describe("getPublicAppSettings", () => {
           misc: {
             amplitudeApiKey: "test-key",
             disableAttachments: true,
+            enableIdleMessage: "true",
             handoffConfiguration: JSON.stringify({
               type: "salesforce",
               enableAvailabilityCheck: true,
@@ -199,6 +200,7 @@ describe("getPublicAppSettings", () => {
       misc: {
         amplitudeApiKey: "test-key",
         disableAttachments: true,
+        enableIdleMessage: true,
         handoffConfiguration: {
           type: "salesforce",
           enableAvailabilityCheck: true,
@@ -207,6 +209,34 @@ describe("getPublicAppSettings", () => {
           allowAnonymousHandoff: true,
         },
       },
+    });
+  });
+
+  describe("enableIdleMessage parsing", () => {
+    it.each([
+      ["true", true],
+      ["1", true],
+      ["false", false],
+      ["0", false],
+      ["", false],
+      [undefined, false],
+    ])("parses enableIdleMessage %s as %s", async (input, expected) => {
+      const mockClient = {
+        appSettings: {
+          get: vi.fn().mockResolvedValue({
+            branding: {},
+            security: {},
+            misc: {
+              enableIdleMessage: input,
+            },
+          }),
+        },
+      };
+
+      vi.mocked(getMavenAGIClient).mockReturnValue(mockClient as any);
+
+      const result = await getPublicAppSettings("org-id", "agent-id");
+      expect(result?.misc.enableIdleMessage).toBe(expected);
     });
   });
 

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -170,8 +170,8 @@ describe("getPublicAppSettings", () => {
           },
           misc: {
             amplitudeApiKey: "test-key",
-            disableAttachments: true,
-            enableIdleMessage: "true",
+            disableAttachments: "true",
+            idleMessageTimeout: "30000",
             handoffConfiguration: JSON.stringify({
               type: "salesforce",
               enableAvailabilityCheck: true,
@@ -200,7 +200,7 @@ describe("getPublicAppSettings", () => {
       misc: {
         amplitudeApiKey: "test-key",
         disableAttachments: true,
-        enableIdleMessage: true,
+        idleMessageTimeout: 30000,
         handoffConfiguration: {
           type: "salesforce",
           enableAvailabilityCheck: true,
@@ -212,22 +212,23 @@ describe("getPublicAppSettings", () => {
     });
   });
 
-  describe("enableIdleMessage parsing", () => {
+  describe("idleMessageTimeout parsing", () => {
     it.each([
-      ["true", true],
-      ["1", true],
-      ["false", false],
-      ["0", false],
-      ["", false],
-      [undefined, false],
-    ])("parses enableIdleMessage %s as %s", async (input, expected) => {
+      ["30000", 30000],
+      ["1000", 1000],
+      ["0", undefined],
+      ["-1000", undefined],
+      ["invalid", undefined],
+      ["", undefined],
+      [undefined, undefined],
+    ])("parses idleMessageTimeout %s as %s", async (input, expected) => {
       const mockClient = {
         appSettings: {
           get: vi.fn().mockResolvedValue({
             branding: {},
             security: {},
             misc: {
-              enableIdleMessage: input,
+              idleMessageTimeout: input,
             },
           }),
         },
@@ -236,7 +237,36 @@ describe("getPublicAppSettings", () => {
       vi.mocked(getMavenAGIClient).mockReturnValue(mockClient as any);
 
       const result = await getPublicAppSettings("org-id", "agent-id");
-      expect(result?.misc.enableIdleMessage).toBe(expected);
+      expect(result?.misc.idleMessageTimeout).toBe(expected);
+    });
+  });
+
+  describe("disableAttachments parsing", () => {
+    it.each([
+      ["true", true],
+      ["1", true],
+      ["false", false],
+      ["0", false],
+      ["", false],
+      [undefined, false],
+      ["anything-else", false],
+    ])("parses disableAttachments %s as %s", async (input, expected) => {
+      const mockClient = {
+        appSettings: {
+          get: vi.fn().mockResolvedValue({
+            branding: {},
+            security: {},
+            misc: {
+              disableAttachments: input,
+            },
+          }),
+        },
+      };
+
+      vi.mocked(getMavenAGIClient).mockReturnValue(mockClient as any);
+
+      const result = await getPublicAppSettings("org-id", "agent-id");
+      expect(result?.misc.disableAttachments).toBe(expected);
     });
   });
 

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -1,0 +1,164 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { NEXT_LOCALE_HEADER } from "@/app/constants/internationalization";
+import { getRequestConfigHandler } from "@/i18n";
+
+// Mock next/headers
+const headerMap = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get: (key: string) => headerMap.get(key),
+  }),
+}));
+
+// Mock message files
+vi.mock("@/messages/en.json", () => ({
+  default: { test: "Test Message" },
+}));
+
+vi.mock("@/messages/es.json", () => ({
+  default: { test: "Mensaje de Prueba" },
+}));
+
+// Mock fr.json to simulate it not existing
+vi.mock("@/messages/fr.json", () => ({
+  default: null,
+}));
+
+// Mock de.json to simulate it not existing
+vi.mock("@/messages/de.json", () => ({
+  default: null,
+}));
+
+describe("i18n configuration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    headerMap.clear();
+  });
+
+  it("should handle basic locale configuration", async () => {
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("en"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "en",
+        messages: expect.objectContaining({ test: "Test Message" }),
+      }),
+    );
+  });
+
+  it("should support Spanish locale", async () => {
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("es"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "es",
+        messages: expect.objectContaining({ test: "Mensaje de Prueba" }),
+      }),
+    );
+  });
+
+  it("should normalize locale codes to base locale", async () => {
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("en-US"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "en",
+        messages: expect.objectContaining({ test: "Test Message" }),
+      }),
+    );
+  });
+
+  it("should fall back to English for unsupported locales", async () => {
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("fr"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "en",
+        messages: expect.objectContaining({ test: "Test Message" }),
+      }),
+    );
+  });
+
+  it("should handle invalid locale gracefully", async () => {
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("invalid"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "en",
+        messages: expect.objectContaining({ test: "Test Message" }),
+      }),
+    );
+  });
+
+  it("should respect locale from URL header", async () => {
+    headerMap.set(NEXT_LOCALE_HEADER, "es");
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("en"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "es",
+        messages: expect.objectContaining({ test: "Mensaje de Prueba" }),
+      }),
+    );
+  });
+
+  it("should handle accept-language header", async () => {
+    headerMap.set("accept-language", "es-ES,es;q=0.9,en;q=0.8");
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("en"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "es",
+        messages: expect.objectContaining({ test: "Mensaje de Prueba" }),
+      }),
+    );
+  });
+
+  it("should prioritize URL locale over accept-language", async () => {
+    headerMap.set(NEXT_LOCALE_HEADER, "en");
+    headerMap.set("accept-language", "es-ES,es;q=0.9,en;q=0.8");
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("es"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "en",
+        messages: expect.objectContaining({ test: "Test Message" }),
+      }),
+    );
+  });
+
+  it("should handle complex accept-language headers", async () => {
+    headerMap.set("accept-language", "fr-FR,fr;q=0.9,es;q=0.8,en;q=0.7");
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("en"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "es",
+        messages: expect.objectContaining({ test: "Mensaje de Prueba" }),
+      }),
+    );
+  });
+
+  it("should fall back to English for unsupported accept-language locales", async () => {
+    headerMap.set("accept-language", "fr-FR,fr;q=0.9,de;q=0.8");
+    const config = await getRequestConfigHandler({
+      requestLocale: Promise.resolve("en"),
+    });
+    expect(config).toEqual(
+      expect.objectContaining({
+        locale: "en",
+        messages: expect.objectContaining({ test: "Test Message" }),
+      }),
+    );
+  });
+});

--- a/__tests__/lib/useIdleMessage.test.ts
+++ b/__tests__/lib/useIdleMessage.test.ts
@@ -1,0 +1,272 @@
+import { renderHook, act } from "@testing-library/react";
+import { useIdleMessage } from "@/lib/useIdleMessage";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useTranslations } from "next-intl";
+import { useAnalytics } from "@/lib/use-analytics";
+import { useParams } from "next/navigation";
+import { useSettings } from "@/app/providers/SettingsProvider";
+import { MagiEvent } from "@/lib/analytics/events";
+import type { ChatMessage, CombinedMessage } from "@/types";
+
+// Mock dependencies
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+}));
+
+vi.mock("@/lib/use-analytics", () => ({
+  useAnalytics: vi.fn(),
+}));
+
+vi.mock("@/app/providers/SettingsProvider", () => ({
+  useSettings: vi.fn(),
+}));
+
+describe("useIdleMessage", () => {
+  const mockAddMessage = vi.fn();
+  const mockLogEvent = vi.fn();
+  const mockTranslate = vi.fn();
+  const defaultProps = {
+    idleTimeout: 1000,
+    messages: [] as CombinedMessage[],
+    conversationId: "test-conversation",
+    agentName: "",
+    addMessage: mockAddMessage,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    // Setup mocks
+    (useTranslations as any).mockReturnValue(mockTranslate);
+    (useParams as any).mockReturnValue({ agentId: "test-agent" });
+    (useAnalytics as any).mockReturnValue({ logEvent: mockLogEvent });
+    (useSettings as any).mockReturnValue({
+      misc: {
+        handoffConfiguration: {
+          surveyLink: "https://test-survey.com",
+        },
+        enableIdleMessage: true,
+      },
+    });
+
+    mockTranslate.mockImplementation((key: string, params: any) => {
+      return `Translated ${key} with ${JSON.stringify(params)}`;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should not show idle message if feature is disabled", () => {
+    (useSettings as any).mockReturnValue({
+      misc: {
+        handoffConfiguration: {
+          surveyLink: "https://test-survey.com",
+        },
+        enableIdleMessage: false,
+      },
+    });
+
+    const props = {
+      ...defaultProps,
+      messages: [
+        { type: "USER", text: "Hello", timestamp: Date.now() },
+      ] as CombinedMessage[],
+    };
+
+    renderHook(() => useIdleMessage(props));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+    expect(mockLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("should not show idle message if no user messages exist", () => {
+    renderHook(() => useIdleMessage(defaultProps));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+  });
+
+  it("should show idle message after timeout when user messages exist", () => {
+    const userMessage: ChatMessage = {
+      text: "Hello",
+      type: "USER",
+      timestamp: Date.now(),
+    };
+
+    const props = {
+      ...defaultProps,
+      messages: [userMessage] as CombinedMessage[],
+    };
+
+    renderHook(() => useIdleMessage(props));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockAddMessage).toHaveBeenCalledTimes(1);
+    expect(mockLogEvent).toHaveBeenCalledWith(MagiEvent.idleMessageDisplay, {
+      agentId: "test-agent",
+      conversationId: "test-conversation",
+      agentConnected: false,
+    });
+  });
+
+  it("should not show idle message if already shown", () => {
+    const userMessage: ChatMessage = {
+      text: "Hello",
+      type: "USER",
+      timestamp: Date.now(),
+    };
+
+    const props = {
+      ...defaultProps,
+      messages: [userMessage] as CombinedMessage[],
+    };
+
+    renderHook(() => useIdleMessage(props));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockAddMessage).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockAddMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reset timer on user activity", () => {
+    const userMessage: ChatMessage = {
+      text: "Hello",
+      type: "USER",
+      timestamp: Date.now(),
+    };
+
+    const props = {
+      ...defaultProps,
+      messages: [userMessage] as CombinedMessage[],
+    };
+
+    renderHook(() => useIdleMessage(props));
+
+    // Advance halfway through the timeout
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // Simulate user activity
+    act(() => {
+      window.dispatchEvent(new Event("mousemove"));
+    });
+
+    // Advance past the original timeout
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+
+    // Advance to the new timeout
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockAddMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should track agent connection status", () => {
+    const userMessage: ChatMessage = {
+      text: "Hello",
+      type: "USER",
+      timestamp: Date.now(),
+    };
+
+    const props = {
+      ...defaultProps,
+      messages: [userMessage] as CombinedMessage[],
+      agentName: "New Agent",
+    };
+
+    renderHook(() => useIdleMessage(props));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockLogEvent).toHaveBeenCalledWith(MagiEvent.idleMessageDisplay, {
+      agentId: "test-agent",
+      conversationId: "test-conversation",
+      agentConnected: true,
+    });
+  });
+
+  it("should not show idle message if survey link is not configured", () => {
+    (useSettings as any).mockReturnValue({
+      misc: {
+        handoffConfiguration: {
+          surveyLink: undefined,
+        },
+        enableIdleMessage: true,
+      },
+    });
+
+    const userMessage: ChatMessage = {
+      text: "Hello",
+      type: "USER",
+      timestamp: Date.now(),
+    };
+
+    const props = {
+      ...defaultProps,
+      messages: [userMessage] as CombinedMessage[],
+    };
+
+    renderHook(() => useIdleMessage(props));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+  });
+
+  it("should cleanup timers and event listeners on unmount", () => {
+    const userMessage: ChatMessage = {
+      text: "Hello",
+      type: "USER",
+      timestamp: Date.now(),
+    };
+
+    const props = {
+      ...defaultProps,
+      messages: [userMessage] as CombinedMessage[],
+    };
+
+    const { unmount } = renderHook(() => useIdleMessage(props));
+
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/useIdleMessage.test.ts
+++ b/__tests__/lib/useIdleMessage.test.ts
@@ -48,7 +48,7 @@ describe("useIdleMessage", () => {
         handoffConfiguration: {
           surveyLink: "https://test-survey.com",
         },
-        idleMessageTimeout: 30000,
+        idleMessageTimeout: 30, // 30 seconds
       },
     });
 
@@ -115,7 +115,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(30000); // Use the default timeout from settings
+      vi.advanceTimersByTime(30000); // 30 seconds in milliseconds
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
@@ -141,13 +141,13 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(30000);
+      vi.advanceTimersByTime(30000); // 30 seconds in milliseconds
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
 
     act(() => {
-      vi.advanceTimersByTime(30000);
+      vi.advanceTimersByTime(30000); // Another 30 seconds
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
@@ -169,7 +169,7 @@ describe("useIdleMessage", () => {
 
     // Advance halfway through the timeout
     act(() => {
-      vi.advanceTimersByTime(15000);
+      vi.advanceTimersByTime(15000); // 15 seconds
     });
 
     // Simulate user activity
@@ -179,14 +179,14 @@ describe("useIdleMessage", () => {
 
     // Advance past the original timeout
     act(() => {
-      vi.advanceTimersByTime(20000);
+      vi.advanceTimersByTime(20000); // 20 seconds
     });
 
     expect(mockAddMessage).not.toHaveBeenCalled();
 
     // Advance to the new timeout
     act(() => {
-      vi.advanceTimersByTime(15000);
+      vi.advanceTimersByTime(15000); // Final 15 seconds
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
@@ -208,7 +208,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(30000);
+      vi.advanceTimersByTime(30000); // 30 seconds in milliseconds
     });
 
     expect(mockLogEvent).toHaveBeenCalledWith(MagiEvent.idleMessageDisplay, {
@@ -224,7 +224,7 @@ describe("useIdleMessage", () => {
         handoffConfiguration: {
           surveyLink: undefined,
         },
-        idleMessageTimeout: 30000,
+        idleMessageTimeout: 30, // 30 seconds
       },
     });
 
@@ -242,7 +242,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(30000);
+      vi.advanceTimersByTime(30000); // 30 seconds in milliseconds
     });
 
     expect(mockAddMessage).not.toHaveBeenCalled();

--- a/__tests__/lib/useIdleMessage.test.ts
+++ b/__tests__/lib/useIdleMessage.test.ts
@@ -30,7 +30,6 @@ describe("useIdleMessage", () => {
   const mockLogEvent = vi.fn();
   const mockTranslate = vi.fn();
   const defaultProps = {
-    idleTimeout: 1000,
     messages: [] as CombinedMessage[],
     conversationId: "test-conversation",
     agentName: "",
@@ -49,7 +48,7 @@ describe("useIdleMessage", () => {
         handoffConfiguration: {
           surveyLink: "https://test-survey.com",
         },
-        enableIdleMessage: true,
+        idleMessageTimeout: 30000,
       },
     });
 
@@ -64,13 +63,13 @@ describe("useIdleMessage", () => {
     vi.useRealTimers();
   });
 
-  it("should not show idle message if feature is disabled", () => {
+  it("should not show idle message if timeout is undefined", () => {
     (useSettings as any).mockReturnValue({
       misc: {
         handoffConfiguration: {
           surveyLink: "https://test-survey.com",
         },
-        enableIdleMessage: false,
+        idleMessageTimeout: undefined,
       },
     });
 
@@ -84,7 +83,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(60000); // Advance well beyond any reasonable timeout
     });
 
     expect(mockAddMessage).not.toHaveBeenCalled();
@@ -95,7 +94,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(defaultProps));
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(60000);
     });
 
     expect(mockAddMessage).not.toHaveBeenCalled();
@@ -116,7 +115,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(30000); // Use the default timeout from settings
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
@@ -142,13 +141,13 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(30000);
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(30000);
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
@@ -170,7 +169,7 @@ describe("useIdleMessage", () => {
 
     // Advance halfway through the timeout
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(15000);
     });
 
     // Simulate user activity
@@ -180,14 +179,14 @@ describe("useIdleMessage", () => {
 
     // Advance past the original timeout
     act(() => {
-      vi.advanceTimersByTime(600);
+      vi.advanceTimersByTime(20000);
     });
 
     expect(mockAddMessage).not.toHaveBeenCalled();
 
     // Advance to the new timeout
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(15000);
     });
 
     expect(mockAddMessage).toHaveBeenCalledTimes(1);
@@ -209,7 +208,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(30000);
     });
 
     expect(mockLogEvent).toHaveBeenCalledWith(MagiEvent.idleMessageDisplay, {
@@ -225,7 +224,7 @@ describe("useIdleMessage", () => {
         handoffConfiguration: {
           surveyLink: undefined,
         },
-        enableIdleMessage: true,
+        idleMessageTimeout: 30000,
       },
     });
 
@@ -243,7 +242,7 @@ describe("useIdleMessage", () => {
     renderHook(() => useIdleMessage(props));
 
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(30000);
     });
 
     expect(mockAddMessage).not.toHaveBeenCalled();

--- a/app/[organizationId]/[agentId]/page.tsx
+++ b/app/[organizationId]/[agentId]/page.tsx
@@ -79,9 +79,10 @@ function ChatPage() {
   const isHandoff = handoffStatus === HandoffStatus.INITIALIZED;
 
   useIdleMessage({
-    messages,
-    conversationId,
     agentName: agentName || "",
+    conversationId,
+    isHandoff,
+    messages,
     addMessage,
   });
 

--- a/app/[organizationId]/[agentId]/page.tsx
+++ b/app/[organizationId]/[agentId]/page.tsx
@@ -3,25 +3,28 @@
 import * as React from "react";
 import { useEffect, useMemo } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import Chat from "@magi/components/chat/Chat";
-import { ChatInput } from "@magi/components/chat/ChatInput";
-import { useChat } from "@magi/components/chat/use-chat";
-import { MagiEvent } from "@/lib/analytics/events";
-import { useAnalytics } from "@/lib/use-analytics";
-import { useSettings } from "@/app/providers/SettingsProvider";
-import { useIframeMessaging } from "@/lib/useIframeMessaging";
+
 import { AuthProvider } from "@/app/providers/AuthProvider";
 import { CustomDataProvider } from "@/app/providers/CustomDataProvider";
-import { ChatHeader } from "@magi/components/chat/ChatHeader";
-import { WelcomeMessage } from "@magi/components/chat/WelcomeChatMessage";
-import { ChatMessages } from "@magi/components/chat/ChatMessages";
-import { useAskQuestion } from "@/lib/useAskQuestion";
-import { useScrollToBottom } from "@/lib/useScrollToBottom";
-import { useHandoff } from "@/lib/useHandoff";
+import { useSettings } from "@/app/providers/SettingsProvider";
 import { HandoffStatus } from "@/app/constants/handoff";
-import { PoweredByMaven } from "@magi/components/chat/PoweredByMaven";
+import { MagiEvent } from "@/lib/analytics/events";
+import { useAnalytics } from "@/lib/use-analytics";
+import { useAskQuestion } from "@/lib/useAskQuestion";
+import { useHandoff } from "@/lib/useHandoff";
+import { useIdleMessage } from "@/lib/useIdleMessage";
+import { useIframeMessaging } from "@/lib/useIframeMessaging";
+import { useScrollToBottom } from "@/lib/useScrollToBottom";
 import type { CombinedMessage } from "@/types";
+
+import Chat from "@magi/components/chat/Chat";
+import { ChatHeader } from "@magi/components/chat/ChatHeader";
+import { ChatInput } from "@magi/components/chat/ChatInput";
+import { ChatMessages } from "@magi/components/chat/ChatMessages";
+import { PoweredByMaven } from "@magi/components/chat/PoweredByMaven";
 import { TypingIndicator } from "@magi/components/chat/TypingIndicator";
+import { useChat } from "@magi/components/chat/use-chat";
+import { WelcomeMessage } from "@magi/components/chat/WelcomeChatMessage";
 
 function ChatPage() {
   const analytics = useAnalytics();
@@ -74,6 +77,13 @@ function ChatPage() {
   }, [messages, handoffChatEvents]);
 
   const isHandoff = handoffStatus === HandoffStatus.INITIALIZED;
+
+  useIdleMessage({
+    messages,
+    conversationId,
+    agentName: agentName || "",
+    addMessage,
+  });
 
   return (
     <main className="flex h-screen flex-col bg-gray-50">

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -134,6 +134,9 @@ export async function getPublicAppSettings(
         amplitudeApiKey: settings.misc?.amplitudeApiKey,
         disableAttachments: settings.misc?.disableAttachments,
         handoffConfiguration: parsedHandoffConfiguration,
+        enableIdleMessage:
+          ["true", "1"].includes(settings.misc?.enableIdleMessage || "") ??
+          false,
       },
     };
   } catch (error) {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -132,7 +132,9 @@ export async function getPublicAppSettings(
       },
       misc: {
         amplitudeApiKey: settings.misc?.amplitudeApiKey,
-        disableAttachments: settings.misc?.disableAttachments,
+        disableAttachments:
+          ["true", "1"].includes(settings.misc?.disableAttachments || "") ??
+          false,
         handoffConfiguration: parsedHandoffConfiguration,
         enableIdleMessage:
           ["true", "1"].includes(settings.misc?.enableIdleMessage || "") ??

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -8,7 +8,7 @@ import {
 } from "mavenagi/api";
 import { nanoid } from "nanoid";
 import { getAppSettings } from "@/app/api/server/utils";
-import { adaptLegacySettings } from "@/lib/settings";
+import { adaptLegacySettings, parseIdleMessageTimeout } from "@/lib/settings";
 import { ServerHandoffStrategyFactory } from "@/lib/handoff/ServerHandoffStrategyFactory";
 
 interface CreateOrUpdateFeedbackProps {
@@ -136,9 +136,9 @@ export async function getPublicAppSettings(
           ["true", "1"].includes(settings.misc?.disableAttachments || "") ??
           false,
         handoffConfiguration: parsedHandoffConfiguration,
-        enableIdleMessage:
-          ["true", "1"].includes(settings.misc?.enableIdleMessage || "") ??
-          false,
+        idleMessageTimeout: parseIdleMessageTimeout(
+          settings.misc?.idleMessageTimeout,
+        ),
       },
     };
   } catch (error) {

--- a/app/constants/internationalization.ts
+++ b/app/constants/internationalization.ts
@@ -1,2 +1,19 @@
-export const NEXT_LOCALE_HEADER = "x-next-intl-locale";
-export const PERMITTED_LOCALES = ["en", "fr", "es", "it", "de", "pt"];
+// Header constants
+export const NEXT_LOCALE_HEADER = "x-next-intl-locale" as const;
+export const ACCEPT_LANGUAGE_HEADER = "accept-language" as const;
+
+// Locale configuration
+export const PERMITTED_LOCALES = ["en", "fr", "es", "it", "de", "pt"] as const;
+export type PermittedLocale = (typeof PERMITTED_LOCALES)[number];
+
+// Default values
+export const DEFAULT_LOCALE = "en" as const;
+export const DEFAULT_QUALITY = "q=1.0" as const;
+export const DEFAULT_QUALITY_VALUE = 1.0 as const;
+
+// Error messages
+export const ERROR_MESSAGES = {
+  INVALID_LOCALE: "Invalid locale provided",
+  FAILED_TO_LOAD_MESSAGES: "Failed to load messages for locale",
+  FAILED_TO_LOAD_DEFAULT: "Failed to load default English messages",
+} as const;

--- a/app/constants/internationalization.ts
+++ b/app/constants/internationalization.ts
@@ -1,0 +1,2 @@
+export const NEXT_LOCALE_HEADER = "x-next-intl-locale";
+export const PERMITTED_LOCALES = ["en", "fr", "es", "it", "de", "pt"];

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,8 +1,10 @@
 import { headers } from "next/headers";
 import { getRequestConfig } from "next-intl/server";
 import type { AbstractIntlMessages, IntlConfig } from "use-intl/core";
-
-const PERMITTED_LOCALES = ["en", "fr", "es", "it"];
+import {
+  NEXT_LOCALE_HEADER,
+  PERMITTED_LOCALES,
+} from "./app/constants/internationalization";
 
 // Helper function to get base locale
 function getBaseLocale(locale: string): string {
@@ -21,8 +23,11 @@ export default getRequestConfig(
       let locale = (await requestLocale) || "en";
       const headersList = await headers();
       const acceptLanguage = headersList.get("accept-language");
+      const localeFromUrl = headersList.get(NEXT_LOCALE_HEADER);
 
-      if (acceptLanguage) {
+      if (localeFromUrl) {
+        locale = localeFromUrl;
+      } else if (acceptLanguage) {
         // Get the first matching locale from accept-language header
         const matchedLocale = acceptLanguage
           .split(",")

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,3 +1,12 @@
+/**
+ * Parses a string value into a valid idle message timeout number.
+ * Returns undefined if the value is invalid or not a positive integer.
+ */
+export function parseIdleMessageTimeout(value?: string): number | undefined {
+  const timeout = parseInt(value || "", 10);
+  return !isNaN(timeout) && timeout > 0 ? timeout : undefined;
+}
+
 export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
   const { misc, branding, security } = settings;
 

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -9,6 +9,7 @@ export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
 
   // Set branding properties
   adapted.branding = {
+    ...(adapted.branding || {}),
     logoUrl: settings.branding?.logoUrl ?? settings.logoUrl,
     brandColor: settings.branding?.brandColor ?? settings.brandColor,
     brandFontColor:
@@ -23,6 +24,7 @@ export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
 
   // Set security properties
   adapted.security = {
+    ...(adapted.security || {}),
     jwtPublicKey: settings.security?.jwtPublicKey ?? settings.jwtPublicKey,
     embedAllowlist:
       settings.security?.embedAllowlist ?? settings.embedAllowlist,
@@ -31,6 +33,7 @@ export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
   };
 
   adapted.misc = {
+    ...(adapted.misc || {}),
     handoffConfiguration:
       settings.misc?.handoffConfiguration ?? settings.handoffConfiguration,
     amplitudeApiKey: settings.misc?.amplitudeApiKey ?? settings.amplitudeApiKey,

--- a/lib/useIdleMessage.ts
+++ b/lib/useIdleMessage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useMemo } from "react";
+import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import type { ChatMessage, CombinedMessage } from "@/types";
 import { useTranslations } from "next-intl";
 import { useAnalytics } from "@/lib/use-analytics";
@@ -6,6 +6,10 @@ import { MagiEvent } from "@/lib/analytics/events";
 import { useParams } from "next/navigation";
 import { useSettings } from "@/app/providers/SettingsProvider";
 
+/**
+ * DOM events that reset the idle timer when triggered.
+ * These events indicate user activity within the chat interface.
+ */
 const IDLE_EVENTS = [
   "mousemove",
   "mousedown",
@@ -23,6 +27,15 @@ interface UseIdleMessageProps {
   addMessage: (message: ChatMessage) => void;
 }
 
+/**
+ * Hook that manages the display of an idle message after a configurable period of user inactivity.
+ * Handles user activity monitoring, timer management, and message display logic.
+ *
+ * @param messages - Array of chat messages to determine if user has interacted
+ * @param conversationId - Unique identifier for the current conversation
+ * @param agentName - Name of the agent for connection status tracking
+ * @param addMessage - Callback to add the idle message to the chat
+ */
 export function useIdleMessage({
   messages,
   conversationId,
@@ -31,13 +44,31 @@ export function useIdleMessage({
 }: UseIdleMessageProps) {
   const { misc } = useSettings();
   const t = useTranslations("chat.IdleMessage");
-  const hasShownMessage = useRef(false);
+  const [showMessage, setShowMessage] = useState(false);
   const hasConnectedToAgent = useRef(false);
   const timer = useRef<NodeJS.Timeout>();
+  const hasDisplayedMessage = useRef(false);
   const analytics = useAnalytics();
   const { agentId } = useParams();
   const surveyLink = misc.handoffConfiguration?.surveyLink;
 
+  /**
+   * Removes event listeners and clears the idle timer.
+   * Used during cleanup and when the idle message is displayed.
+   */
+  const cleanup = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+    }
+    IDLE_EVENTS.forEach((event) => {
+      window.removeEventListener(event, resetTimer);
+    });
+  }, []);
+
+  /**
+   * Logs idle message display event with relevant metadata.
+   */
   const callAnalytics = useCallback(() => {
     analytics.logEvent(MagiEvent.idleMessageDisplay, {
       agentId,
@@ -46,73 +77,97 @@ export function useIdleMessage({
     });
   }, [analytics, agentId, conversationId]);
 
+  /**
+   * Determines if user has sent any messages in the conversation.
+   */
   const userMessagesExist = useMemo(
     () => messages.some((message) => message.type === "USER"),
     [messages],
   );
 
+  /**
+   * Tracks agent connection status for analytics and message content.
+   */
   useEffect(() => {
     if (agentName && !hasConnectedToAgent.current) {
       hasConnectedToAgent.current = true;
     }
   }, [agentName]);
 
+  /**
+   * Memoized idle message content with survey link and conversation metadata.
+   */
+  const idleMessage = useMemo(
+    () => ({
+      text: t("idle_message_with_survey", {
+        url: surveyLink,
+        urlParams: `?chatKey=${conversationId}&agentConnected=${hasConnectedToAgent.current ? "Yes" : "No"}`,
+      }),
+      type: "SIMULATED" as const,
+    }),
+    [t, surveyLink, conversationId, hasConnectedToAgent],
+  );
+
+  /**
+   * Handles the display of the idle message, including analytics and cleanup.
+   * Guarded by surveyLink availability check and ensures message is only displayed once.
+   */
+  const displayMessage = useCallback(() => {
+    if (!surveyLink || hasDisplayedMessage.current) return;
+    addMessage(idleMessage);
+    callAnalytics();
+    cleanup();
+    hasDisplayedMessage.current = true;
+  }, [surveyLink, idleMessage, addMessage, callAnalytics, cleanup]);
+
+  /**
+   * Triggers the idle message display when showMessage state changes to true.
+   */
+  useEffect(() => {
+    if (!showMessage) return;
+    displayMessage();
+  }, [showMessage, displayMessage]);
+
+  /**
+   * Manages the idle timer, clearing existing timeouts and setting new ones.
+   * Timer is only set if the message hasn't been shown and timeout is configured.
+   */
   const resetTimer = useCallback(() => {
     if (timer.current) {
       clearTimeout(timer.current);
+      timer.current = undefined;
     }
 
-    const timeoutInMs = misc.idleMessageTimeout
+    if (showMessage || hasDisplayedMessage.current) {
+      return;
+    }
+
+    const timeoutMs = misc.idleMessageTimeout
       ? misc.idleMessageTimeout * 1000
       : undefined;
-
-    if (!timeoutInMs) {
+    if (!timeoutMs) {
       return;
     }
 
     timer.current = setTimeout(() => {
-      if (!hasShownMessage.current) {
-        const idleMessage: ChatMessage = {
-          text: t("idle_message_with_survey", {
-            url: surveyLink,
-            urlParams: `?chatKey=${conversationId}&agentConnected=${hasConnectedToAgent.current ? "Yes" : "No"}`,
-          }),
-          type: "SIMULATED",
-        };
+      setShowMessage(true);
+    }, timeoutMs);
+  }, [misc.idleMessageTimeout, showMessage]);
 
-        addMessage(idleMessage);
-        hasShownMessage.current = true;
-        callAnalytics();
-      }
-    }, timeoutInMs);
-  }, [
-    misc.idleMessageTimeout,
-    conversationId,
-    t,
-    callAnalytics,
-    surveyLink,
-    addMessage,
-  ]);
-
+  /**
+   * Sets up and manages event listeners for user activity tracking.
+   * Initializes the idle timer and handles cleanup on unmount or when conditions change.
+   */
   useEffect(() => {
-    // Return early if feature is disabled or conditions aren't met
     if (
       !misc.idleMessageTimeout ||
-      hasShownMessage.current ||
+      showMessage ||
+      hasDisplayedMessage.current ||
       !userMessagesExist ||
       !surveyLink
     ) {
-      return;
+      return cleanup;
     }
-
-    const cleanup = () => {
-      if (timer.current) {
-        clearTimeout(timer.current);
-      }
-      IDLE_EVENTS.forEach((event) => {
-        window.removeEventListener(event, resetTimer);
-      });
-    };
 
     IDLE_EVENTS.forEach((event) => {
       window.addEventListener(event, resetTimer);
@@ -121,5 +176,12 @@ export function useIdleMessage({
     resetTimer();
 
     return cleanup;
-  }, [resetTimer, userMessagesExist, surveyLink, misc.idleMessageTimeout]);
+  }, [
+    resetTimer,
+    userMessagesExist,
+    surveyLink,
+    misc.idleMessageTimeout,
+    showMessage,
+    cleanup,
+  ]);
 }

--- a/lib/useIdleMessage.ts
+++ b/lib/useIdleMessage.ts
@@ -62,6 +62,14 @@ export function useIdleMessage({
       clearTimeout(timer.current);
     }
 
+    const timeoutInMs = misc.idleMessageTimeout
+      ? misc.idleMessageTimeout * 1000
+      : undefined;
+
+    if (!timeoutInMs) {
+      return;
+    }
+
     timer.current = setTimeout(() => {
       if (!hasShownMessage.current) {
         const idleMessage: ChatMessage = {
@@ -76,7 +84,7 @@ export function useIdleMessage({
         hasShownMessage.current = true;
         callAnalytics();
       }
-    }, misc.idleMessageTimeout);
+    }, timeoutInMs);
   }, [
     misc.idleMessageTimeout,
     conversationId,

--- a/lib/useIdleMessage.ts
+++ b/lib/useIdleMessage.ts
@@ -17,7 +17,6 @@ const IDLE_EVENTS = [
 ] as const;
 
 interface UseIdleMessageProps {
-  idleTimeout?: number;
   messages: CombinedMessage[];
   conversationId: string;
   agentName: string;
@@ -25,7 +24,6 @@ interface UseIdleMessageProps {
 }
 
 export function useIdleMessage({
-  idleTimeout = 30000,
   messages,
   conversationId,
   agentName,
@@ -78,13 +76,20 @@ export function useIdleMessage({
         hasShownMessage.current = true;
         callAnalytics();
       }
-    }, idleTimeout);
-  }, [idleTimeout, conversationId, t, callAnalytics, surveyLink, addMessage]);
+    }, misc.idleMessageTimeout);
+  }, [
+    misc.idleMessageTimeout,
+    conversationId,
+    t,
+    callAnalytics,
+    surveyLink,
+    addMessage,
+  ]);
 
   useEffect(() => {
     // Return early if feature is disabled or conditions aren't met
     if (
-      !misc.enableIdleMessage ||
+      !misc.idleMessageTimeout ||
       hasShownMessage.current ||
       !userMessagesExist ||
       !surveyLink
@@ -108,5 +113,5 @@ export function useIdleMessage({
     resetTimer();
 
     return cleanup;
-  }, [resetTimer, userMessagesExist, surveyLink, misc.enableIdleMessage]);
+  }, [resetTimer, userMessagesExist, surveyLink, misc.idleMessageTimeout]);
 }

--- a/lib/useIdleMessage.ts
+++ b/lib/useIdleMessage.ts
@@ -5,6 +5,7 @@ import { useAnalytics } from "@/lib/use-analytics";
 import { MagiEvent } from "@/lib/analytics/events";
 import { useParams } from "next/navigation";
 import { useSettings } from "@/app/providers/SettingsProvider";
+
 interface UseIdleMessageProps {
   idleTimeout?: number;
   messages: CombinedMessage[];
@@ -20,13 +21,18 @@ export function useIdleMessage({
   agentName,
   addMessage,
 }: UseIdleMessageProps) {
+  const { misc } = useSettings();
+
+  if (!misc.enableIdleMessage) {
+    return;
+  }
+
   const t = useTranslations("chat.IdleMessage");
   const hasShownMessage = useRef(false);
   const hasConnectedToAgent = useRef(false);
   const timer = useRef<NodeJS.Timeout>();
   const analytics = useAnalytics();
   const { agentId } = useParams();
-  const { misc } = useSettings();
   const surveyLink = misc.handoffConfiguration?.surveyLink;
 
   const callAnalytics = useCallback(() => {
@@ -57,9 +63,8 @@ export function useIdleMessage({
       if (!hasShownMessage.current) {
         const idleMessage: ChatMessage = {
           text: t("idle_message_with_survey", {
-            surveyLink,
-            conversationId,
-            additionalUrlParams: `&agentConnected=${hasConnectedToAgent.current ? "Yes" : "No"}`,
+            url: surveyLink,
+            urlParams: `?chatKey=${conversationId}&agentConnected=${hasConnectedToAgent.current ? "Yes" : "No"}`,
           }),
           type: "SIMULATED",
         };

--- a/lib/useIdleMessage.ts
+++ b/lib/useIdleMessage.ts
@@ -90,11 +90,11 @@ export function useIdleMessage({
    */
   const shouldDisplayMessage = useMemo(() => {
     return showMessage && surveyLink && !hasDisplayedMessage.current;
-  }, [showMessage, surveyLink, isHandoff, hasValidConfiguration]);
+  }, [showMessage, surveyLink]);
 
   const shouldDisplayMessageOnHandoffChange = useMemo(() => {
     return !isHandoff && isHandoffRef.current && hasValidConfiguration;
-  }, [isHandoff, isHandoffRef.current, hasValidConfiguration]);
+  }, [isHandoff, hasValidConfiguration]);
 
   /**
    * Manages timer lifecycle:

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,0 +1,75 @@
+{
+  "chat": {
+    "ChatPage": {
+      "default_welcome_message": "Wie können wir Ihnen helfen? Sie können unten ein Gespräch beginnen oder mit beliebten Fragen starten:",
+      "default_error_message": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
+      "related_links": "Verwandte Links",
+      "powered_by": "Bereitgestellt von",
+      "connecting_to_agent": "Wir verbinden Sie mit einem Live-Agenten...",
+      "agent_typing": "Der Agent tippt...",
+      "error_rendering_chart": "Fehler beim Rendern des Diagramms",
+      "chat_queue_position": "Sie sind an Position {position} in der Warteschlange. Sie werden in Kürze mit einem Agenten verbunden.",
+      "chat_queue_position_next": "Sie sind als Nächstes in der Warteschlange. Ihr Agent wird in Kürze bei Ihnen sein.",
+      "chat_queue_position_in_queue": "Sie sind in der Warteschlange. Bitte warten Sie auf den nächsten verfügbaren Agenten.",
+      "chat_queue_position_estimated_wait_time": "Ihre geschätzte Wartezeit beträgt {estimatedWaitTime} Sekunden.",
+      "chat_queue_position_estimated_wait_time_singular": "Ihre geschätzte Wartezeit beträgt {estimatedWaitTime} Sekunde."
+    },
+    "BailoutFormDisplay": {
+      "unable_to_answer": "Ich kann diese Frage nicht beantworten.",
+      "default_bailout_text": "Bitte versuchen Sie eine andere Frage oder kontaktieren Sie einen Support-Agenten für weitere Unterstützung.",
+      "integration_bailout_text": "Bitte klicken Sie auf die Schaltfläche unten, um sich mit einem Agenten zu verbinden, oder stellen Sie eine andere Frage.",
+      "name": "Name",
+      "email": "E-Mail",
+      "question": "Frage",
+      "ticket_created_title": "Support-Ticket erfolgreich erstellt",
+      "ticket_created_description": "Ein Agent wird sich innerhalb von 24-48 Stunden bei Ihnen melden",
+      "send": "Senden"
+    },
+    "EscalationFormDisplay": {
+      "connect_to_live_agent": "Mit einem Live-Agenten verbinden",
+      "connection_to_live_agent_success_title": "Sie werden jetzt mit einem Live-Agenten verbunden",
+      "connection_to_live_agent_success_description": "Bitte warten Sie, bis der Agent antwortet.",
+      "email_placeholder": "E-Mail-Adresse",
+      "agents_unavailable": "Derzeit sind keine Agenten verfügbar. Bitte versuchen Sie es später erneut."
+    },
+    "Handoff": {
+      "connected_to_agent": "Mit Agent verbunden",
+      "connecting_to_agent": "Wir verbinden Sie mit einem Live-Agenten...",
+      "chat_has_ended": "Chat wurde beendet",
+      "chat_transferred": "Agent {name} hat den Chat betreten",
+      "chat_queue_position": "Sie sind an Position {position} in der Warteschlange. Sie werden in Kürze mit einem Agenten verbunden.",
+      "chat_queue_position_next": "Sie sind als Nächstes in der Warteschlange. Ihr Agent wird in Kürze bei Ihnen sein.",
+      "chat_queue_position_in_queue": "Sie sind in der Warteschlange. Bitte warten Sie auf den nächsten verfügbaren Agenten.",
+      "chat_queue_position_estimated_wait_time": "Ihre geschätzte Wartezeit beträgt {estimatedWaitTime} Sekunden.",
+      "chat_queue_position_estimated_wait_time_singular": "Ihre geschätzte Wartezeit beträgt {estimatedWaitTime} Sekunde.",
+      "salesforce_chat_request_fail_unavailable": "Es tut uns leid, aber derzeit sind keine Live-Agenten verfügbar."
+    },
+    "IdleMessage": {
+      "idle_message": "Wir sind hier, um Ihnen zu helfen. Bitte stellen Sie eine Frage.",
+      "idle_message_with_survey": "Vielen Dank, dass Sie uns kontaktiert haben. Können Sie bitte diese [Umfrage]({url}{urlParams}) ausfüllen, um uns über Ihre Erfahrung zu berichten?"
+    },
+    "ChatInput": {
+      "see_more": "Mehr anzeigen",
+      "see_less": "Weniger anzeigen",
+      "question_placeholder": "Stellen Sie eine Frage...",
+      "speaking_with_agent": "Mit Agent sprechen",
+      "end_chat": "Chat beenden",
+      "aria_submit_question": "Frage absenden",
+      "aria_question_box": "Fragefeld"
+    },
+    "FeedbackForm": {
+      "submit_error": "Fehler beim Absenden des Feedbacks",
+      "submit_success": "Danke für Ihr Feedback!",
+      "thumbs_up": "Daumen hoch",
+      "thumbs_down": "Daumen runter",
+      "human_agent_requested": "Menschlicher Agent angefordert",
+      "copied_to_clipboard": "In die Zwischenablage kopiert",
+      "copy_to_clipboard": "In die Zwischenablage kopieren",
+      "speak_to_agent": "Mit Agent sprechen",
+      "feedback_reason": "Warum haben Sie dieses Feedback ausgewählt?",
+      "down_placeholder": "Lassen Sie uns wissen, wie die Antwort verbessert werden kann.",
+      "up_placeholder": "Was hat Ihnen an der Antwort gefallen?",
+      "submit": "Absenden"
+    }
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,8 +8,6 @@
       "connecting_to_agent": "Connecting you with a live agent...",
       "agent_typing": "Agent is typing...",
       "error_rendering_chart": "Error rendering chart",
-      "idle_message": "We are here to help you. Please ask a question.",
-      "idle_message_with_survey": "Thank you for reaching out. Can you please fill out this [survey]({url}{urlParams}) to tell us about your experience?",
       "chat_queue_position": "You are in position {position} in the queue. You will be connected to an agent shortly.",
       "chat_queue_position_next": "You are next in line in the queue. Your agent will be with you shortly.",
       "chat_queue_position_in_queue": "You are in the queue. Please wait for the next available agent.",
@@ -48,7 +46,7 @@
     },
     "IdleMessage": {
       "idle_message": "We are here to help you. Please ask a question.",
-      "idle_message_with_survey": "Thank you for reaching out. Can you please fill out this [survey]({surveyLink}?chatKey={conversationId}{additionalUrlParams}) to tell us about your experience?"
+      "idle_message_with_survey": "Thank you for reaching out. Can you please fill out this [survey]({url}{urlParams}) to tell us about your experience?"
     },
     "ChatInput": {
       "see_more": "See more",

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,8 +8,6 @@
       "connecting_to_agent": "Conectándote con un agente en vivo...",
       "agent_typing": "El agente está escribiendo...",
       "error_rendering_chart": "Error al renderizar el gráfico",
-      "idle_message": "Estamos aquí para ayudarte. Por favor, haz una pregunta.",
-      "idle_message_with_survey": "Gracias por contactarnos. ¿Podrías llenar esta [encuesta]({url}{urlParams}) para contarnos sobre tu experiencia?",
       "chat_queue_position": "Estás en la posición {position} en la cola. Serás conectado con un agente en breve.",
       "chat_queue_position_next": "Eres el siguiente en la cola. Tu agente estará contigo en breve.",
       "chat_queue_position_in_queue": "Estás en la cola. Por favor, espera al siguiente agente disponible.",
@@ -48,7 +46,7 @@
     },
     "IdleMessage": {
       "idle_message": "Estamos aquí para ayudarte. Por favor, haz una pregunta.",
-      "idle_message_with_survey": "Gracias por contactarnos. ¿Podrías llenar esta [encuesta]({surveyLink}?chatKey={conversationId}{additionalUrlParams}) para contarnos sobre tu experiencia?"
+      "idle_message_with_survey": "Gracias por contactarnos. ¿Podrías llenar esta [encuesta]({url}{urlParams}) para contarnos sobre tu experiencia?"
     },
     "ChatInput": {
       "see_more": "Ver más",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8,8 +8,6 @@
       "connecting_to_agent": "Connexion à un agent en direct...",
       "agent_typing": "L'agent est en train de taper...",
       "error_rendering_chart": "Erreur lors du rendu du graphique",
-      "idle_message": "Nous sommes là pour vous aider. Veuillez poser une question.",
-      "idle_message_with_survey": "Merci de nous avoir contacté. Pouvez-vous remplir ce [sondage]({url}{urlParams}) pour nous parler de votre expérience ?",
       "chat_queue_position": "Vous êtes en position {position} dans la file d'attente. Vous serez connecté à un agent sous peu.",
       "chat_queue_position_next": "Vous êtes le prochain dans la file d'attente. Votre agent sera avec vous sous peu.",
       "chat_queue_position_in_queue": "Vous êtes dans la file d'attente. Veuillez attendre l'agent disponible suivant.",
@@ -48,7 +46,7 @@
     },
     "IdleMessage": {
       "idle_message": "Nous sommes là pour vous aider. Veuillez poser une question.",
-      "idle_message_with_survey": "Merci de nous avoir contacté. Pouvez-vous remplir ce [sondage]({surveyLink}?chatKey={conversationId}{additionalUrlParams}) pour nous parler de votre expérience ?"
+      "idle_message_with_survey": "Merci de nous avoir contacté. Pouvez-vous remplir ce [sondage]({url}{urlParams}) pour nous parler de votre expérience ?"
     },
     "ChatInput": {
       "see_more": "Voir plus",

--- a/messages/it.json
+++ b/messages/it.json
@@ -8,8 +8,6 @@
       "connecting_to_agent": "Connessione con un agente in diretta...",
       "agent_typing": "L'agente sta scrivendo...",
       "error_rendering_chart": "Errore nel renderizzare il grafico",
-      "idle_message": "Siamo qui per aiutarti. Per favore fai una domanda.",
-      "idle_message_with_survey": "Grazie per averci contattato. Puoi compilare questo [sondaggio]({url}{urlParams}) per raccontarci la tua esperienza?",
       "chat_queue_position": "Sei in posizione {position} nella coda. Sarai connesso a un agente a breve.",
       "chat_queue_position_next": "Sei il prossimo in coda. Il tuo agente sarà con te a breve.",
       "chat_queue_position_in_queue": "Sei in coda. Attendi il prossimo agente disponibile.",
@@ -48,7 +46,7 @@
     },
     "IdleMessage": {
       "idle_message": "Siamo qui per aiutarti. Per favore fai una domanda.",
-      "idle_message_with_survey": "Grazie per averci contattato. Puoi compilare questo [sondaggio]({surveyLink}?chatKey={conversationId}{additionalUrlParams}) per raccontarci la tua esperienza?"
+      "idle_message_with_survey": "Grazie per averci contattato. Puoi compilare questo [sondaggio]({url}{urlParams}) per raccontarci la tua esperienza?"
     },
     "ChatInput": {
       "see_more": "Vedi di più",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,0 +1,75 @@
+{
+  "chat": {
+    "ChatPage": {
+      "default_welcome_message": "Como podemos ajudar você? Você pode iniciar uma conversa abaixo ou começar com perguntas populares:",
+      "default_error_message": "Ocorreu um erro. Por favor, tente novamente.",
+      "related_links": "Links relacionados",
+      "powered_by": "Desenvolvido por",
+      "connecting_to_agent": "Conectando você a um agente ao vivo...",
+      "agent_typing": "O agente está digitando...",
+      "error_rendering_chart": "Erro ao renderizar gráfico",
+      "chat_queue_position": "Você está na posição {position} na fila. Você será conectado a um agente em breve.",
+      "chat_queue_position_next": "Você é o próximo na fila. Seu agente estará com você em breve.",
+      "chat_queue_position_in_queue": "Você está na fila. Por favor, aguarde o próximo agente disponível.",
+      "chat_queue_position_estimated_wait_time": "Seu tempo de espera estimado é de {estimatedWaitTime} segundos.",
+      "chat_queue_position_estimated_wait_time_singular": "Seu tempo de espera estimado é de {estimatedWaitTime} segundo."
+    },
+    "BailoutFormDisplay": {
+      "unable_to_answer": "Não consigo responder a esta pergunta.",
+      "default_bailout_text": "Por favor, tente outra pergunta ou entre em contato com um agente de suporte para mais assistência.",
+      "integration_bailout_text": "Por favor, clique no botão abaixo para se conectar a um agente ou faça outra pergunta.",
+      "name": "Nome",
+      "email": "Email",
+      "question": "Pergunta",
+      "ticket_created_title": "Ticket de suporte criado com sucesso",
+      "ticket_created_description": "Um agente entrará em contato com você dentro de 24-48 horas",
+      "send": "Enviar"
+    },
+    "EscalationFormDisplay": {
+      "connect_to_live_agent": "Conectar a um agente ao vivo",
+      "connection_to_live_agent_success_title": "Você está agora se conectando a um agente ao vivo",
+      "connection_to_live_agent_success_description": "Por favor, aguarde a resposta do agente.",
+      "email_placeholder": "Endereço de email",
+      "agents_unavailable": "Nenhum agente está disponível no momento. Por favor, tente novamente mais tarde."
+    },
+    "Handoff": {
+      "connected_to_agent": "Conectado ao agente",
+      "connecting_to_agent": "Conectando você a um agente ao vivo...",
+      "chat_has_ended": "O chat foi encerrado",
+      "chat_transferred": "O agente {name} entrou no chat",
+      "chat_queue_position": "Você está na posição {position} na fila. Você será conectado a um agente em breve.",
+      "chat_queue_position_next": "Você é o próximo na fila. Seu agente estará com você em breve.",
+      "chat_queue_position_in_queue": "Você está na fila. Por favor, aguarde o próximo agente disponível.",
+      "chat_queue_position_estimated_wait_time": "Seu tempo de espera estimado é de {estimatedWaitTime} segundos.",
+      "chat_queue_position_estimated_wait_time_singular": "Seu tempo de espera estimado é de {estimatedWaitTime} segundo.",
+      "salesforce_chat_request_fail_unavailable": "Lamentamos, mas não há agentes ao vivo disponíveis no momento."
+    },
+    "IdleMessage": {
+      "idle_message": "Estamos aqui para ajudar você. Por favor, faça uma pergunta.",
+      "idle_message_with_survey": "Obrigado por entrar em contato. Você pode preencher este [questionário]({url}{urlParams}) para nos contar sobre sua experiência?"
+    },
+    "ChatInput": {
+      "see_more": "Ver mais",
+      "see_less": "Ver menos",
+      "question_placeholder": "Faça uma pergunta...",
+      "speaking_with_agent": "Falando com o agente",
+      "end_chat": "Encerrar chat",
+      "aria_submit_question": "Enviar pergunta",
+      "aria_question_box": "Caixa de perguntas"
+    },
+    "FeedbackForm": {
+      "submit_error": "Erro ao enviar feedback",
+      "submit_success": "Obrigado pelo seu feedback!",
+      "thumbs_up": "Polegar para cima",
+      "thumbs_down": "Polegar para baixo",
+      "human_agent_requested": "Agente humano solicitado",
+      "copied_to_clipboard": "Copiado para a área de transferência",
+      "copy_to_clipboard": "Copiar para a área de transferência",
+      "speak_to_agent": "Falar com agente",
+      "feedback_reason": "Por que você selecionou este feedback?",
+      "down_placeholder": "Deixe-nos saber como a resposta pode ser melhorada.",
+      "up_placeholder": "O que você gostou na resposta?",
+      "submit": "Enviar"
+    }
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { getAppSettings } from "@/app/api/server/utils";
 import { notFound } from "next/navigation";
 import { isNotFoundError } from "next/dist/client/components/not-found";
-
+import { NEXT_LOCALE_HEADER } from "@/app/constants/internationalization";
 // Constants
 const PATHNAMES = [
   "/demo/:organizationId/:agentId/:path*",
@@ -83,6 +83,12 @@ const processSecuritySettings = (
  */
 export async function middleware(request: NextRequest) {
   const response = NextResponse.next();
+
+  // Add locale to the response
+  const locale = request.nextUrl.searchParams.get("locale");
+  if (locale) {
+    response.headers.set(NEXT_LOCALE_HEADER, locale);
+  }
 
   if (
     !["iframe", "document"].includes(

--- a/packages/components/chat/Chat.tsx
+++ b/packages/components/chat/Chat.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useMemo, useState } from "react";
 import { isBotMessage, ChatMessage, CombinedMessage } from "@/types";
 import { useSettings } from "@/app/providers/SettingsProvider";
 import { Attachment } from "mavenagi/api";
-import { useIdleMessage } from "@/lib/useIdleMessage";
 
 interface ChatContextProps {
   agentName: string | null;
@@ -65,12 +64,7 @@ export default function Chat({
 }: React.PropsWithChildren<ChatProps>) {
   const [followUpQuestions, setFollowUpQuestions] = useState<string[]>([]);
   const { branding, misc } = useSettings();
-  useIdleMessage({
-    messages: messages as ChatMessage[],
-    conversationId,
-    agentName: agentName || "",
-    addMessage,
-  });
+
   useEffect(() => {
     if (messages.length > 0) {
       const lastMsg = messages[messages.length - 1];

--- a/packages/widget/src/chat/hooks/useIframeCommunication.ts
+++ b/packages/widget/src/chat/hooks/useIframeCommunication.ts
@@ -41,6 +41,7 @@ export function useIframeCommunication({
   customData,
   isWide,
   isOpen,
+  locale,
 }: {
   organizationId: string;
   agentId: string;
@@ -49,6 +50,7 @@ export function useIframeCommunication({
   customData?: Record<string, any> | null;
   isWide: boolean;
   isOpen: boolean;
+  locale?: string;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -65,6 +67,10 @@ export function useIframeCommunication({
       ? `${currentDomain || "localhost"}:${window.location.port}`
       : __IFRAME_DOMAIN__;
     let iframeUrl = `${iframeProtocol}://${iframeDomain}/${organizationId}/${agentId}`;
+
+    if (locale) {
+      iframeUrl += `?locale=${locale}`;
+    }
 
     return iframeUrl;
   }, [organizationId, agentId]);

--- a/packages/widget/src/chat/index.tsx
+++ b/packages/widget/src/chat/index.tsx
@@ -21,6 +21,7 @@ type Props = {
   bgColor: string;
   textColor: string;
   buttonLabel: string;
+  locale?: string;
   horizontalPosition: "left" | "right";
   verticalPosition: "top" | "bottom";
   signedUserData?: string | null;
@@ -41,6 +42,7 @@ const App = forwardRef<{ open: () => void; close: () => void }, Props>(
       signedUserData: props.signedUserData,
       unsignedUserData: props.unsignedUserData || props.unverifiedUserData,
       customData: props.customData,
+      locale: props.locale,
       isWide,
       isOpen,
     });
@@ -93,8 +95,8 @@ type LoadProps = Partial<Omit<Props, "iframeUrl">> & {
   horizontalPosition?: "left" | "right";
   bgColor?: string;
   textColor?: string;
-} & // "orgFriendlyId" and "agentFriendlyId" to "organizationId" and "agentId". // This union type ensures backwards compatibility during the migration from the
-  // It enforces that either:
+  locale?: string;
+} & // It enforces that either: // "orgFriendlyId" and "agentFriendlyId" to "organizationId" and "agentId". // This union type ensures backwards compatibility during the migration from the
   // 1. Both organizationId and agentId are provided (new spec) OR
   // 2. Both orgFriendlyId and agentFriendlyId are provided (legacy spec)
   // This prevents mixing of old and new ID formats while supporting both patterns
@@ -119,6 +121,7 @@ export async function load({
   buttonLabel = "Get Help",
   horizontalPosition = "right",
   verticalPosition = "bottom",
+  locale,
   organizationId,
   orgFriendlyId,
   agentId,
@@ -138,6 +141,7 @@ export async function load({
       bgColor={bgColor || "#6C2BD9"}
       textColor={textColor}
       buttonLabel={buttonLabel}
+      locale={locale}
       horizontalPosition={horizontalPosition}
       verticalPosition={verticalPosition}
       signedUserData={signedUserData}

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -12,7 +12,7 @@ declare global {
     embedAllowlist?: string[];
     enableDemoSite?: string;
     welcomeMessage?: string;
-    disableAttachments?: boolean;
+    disableAttachments?: string;
   }
 
   interface AppSettings {
@@ -32,7 +32,8 @@ declare global {
     misc: {
       handoffConfiguration?: string;
       amplitudeApiKey?: string;
-      disableAttachments?: boolean;
+      disableAttachments?: string;
+      enableIdleMessage?: string;
     };
   }
 
@@ -98,6 +99,7 @@ declare global {
       amplitudeApiKey?: AppSettings["misc"]["amplitudeApiKey"];
       disableAttachments?: AppSettings["misc"]["disableAttachments"];
       handoffConfiguration?: ClientSafeHandoffConfig;
+      enableIdleMessage?: boolean;
     };
   }
 }

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -33,7 +33,7 @@ declare global {
       handoffConfiguration?: string;
       amplitudeApiKey?: string;
       disableAttachments?: string;
-      enableIdleMessage?: string;
+      idleMessageTimeout?: string;
     };
   }
 
@@ -99,7 +99,7 @@ declare global {
       amplitudeApiKey?: AppSettings["misc"]["amplitudeApiKey"];
       disableAttachments?: boolean;
       handoffConfiguration?: ClientSafeHandoffConfig;
-      enableIdleMessage?: boolean;
+      idleMessageTimeout?: number;
     };
   }
 }

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -97,7 +97,7 @@ declare global {
     };
     misc: {
       amplitudeApiKey?: AppSettings["misc"]["amplitudeApiKey"];
-      disableAttachments?: AppSettings["misc"]["disableAttachments"];
+      disableAttachments?: boolean;
       handoffConfiguration?: ClientSafeHandoffConfig;
       enableIdleMessage?: boolean;
     };


### PR DESCRIPTION
- Add idle timeout setting 
- Call useIdleTimeout on Chat Page Component (disabled if setting is not provided)
- Add manual locale override: widget -> url -> header -> i18n provider
- Add Portuguese and German locale support
- Improve settings type safety with spread operators
- Add tests for idle message and settings parsing