### PR TITLE
feat: add locale search param option on preview page

### DIFF
--- a/app/preview/[organizationId]/[agentId]/Widget.tsx
+++ b/app/preview/[organizationId]/[agentId]/Widget.tsx
@@ -9,6 +9,7 @@ type WidgetLoadPayload = {
   signedUserData?: string;
   unsignedUserData?: Record<string, any>;
   customData?: Record<string, any>;
+  locale?: string;
 };
 
 export default function Widget({
@@ -26,6 +27,8 @@ export default function Widget({
       todaysDate: localizedDate,
     };
   }
+
+  widgetLoadPayload.locale = widgetLoadPayload.customData?.locale || undefined;
 
   return (
     <>

--- a/app/preview/[organizationId]/[agentId]/page.tsx
+++ b/app/preview/[organizationId]/[agentId]/page.tsx
@@ -60,7 +60,7 @@ export default async function Page({
   let parsedCustomData = {};
 
   try {
-    parsedCustomData = JSON.parse(searchParamsCustomData);
+    parsedCustomData = JSON.parse(decodeURIComponent(searchParamsCustomData));
   } catch (error) {
     console.error("Error parsing customData", error);
   }


### PR DESCRIPTION
Adding `?customData={"locale":"fr"}` will get you:
![image](https://github.com/user-attachments/assets/fd0ec65e-62d2-4a18-a7eb-b37950d25d0d)
