### PR TITLE
feat: Add handoff terminating message configuration for Salesforce strategy

### DIFF
--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -178,6 +178,7 @@ describe("getPublicAppSettings", () => {
               surveyLink: "survey.com",
               availabilityFallbackMessage: "message",
               allowAnonymousHandoff: true,
+              handoffTerminatingMessageText: "goodbye",
               apiSecret: "secret", // This should not be included in client settings
             }),
           },
@@ -207,6 +208,7 @@ describe("getPublicAppSettings", () => {
           surveyLink: "survey.com",
           availabilityFallbackMessage: "message",
           allowAnonymousHandoff: true,
+          handoffTerminatingMessageText: "goodbye",
         },
       },
     });

--- a/__tests__/lib/handoff/HandoffStrategyFactory.test.ts
+++ b/__tests__/lib/handoff/HandoffStrategyFactory.test.ts
@@ -5,6 +5,35 @@ import { FrontStrategy } from "@/lib/handoff/FrontStrategy";
 import { SalesforceStrategy } from "@/lib/handoff/SalesforceStrategy";
 
 describe("HandoffStrategyFactory", () => {
+  const salesforceConfig = {
+    type: "salesforce" as const,
+    orgId: "test-org",
+    chatHostUrl: "test-url",
+    chatButtonId: "test-button",
+    deploymentId: "test-deployment",
+    eswLiveAgentDevName: "test-name",
+    apiSecret: "test-secret",
+    handoffTerminatingMessageText: "goodbye",
+  };
+
+  const zendeskConfig = {
+    type: "zendesk" as const,
+    apiKey: "test-api-key",
+    apiSecret: "test-api-secret",
+    appId: "test-app-id",
+    webhookId: "test-webhook-id",
+    webhookSecret: "test-webhook-secret",
+    subdomain: "test-subdomain",
+  };
+
+  const frontConfig = {
+    type: "front" as const,
+    apiKey: "test-api-key",
+    apiSecret: "test-api-secret",
+    appId: "test-app-id",
+    channelName: "test-channel",
+  };
+
   it("creates a ZendeskStrategy for zendesk type", () => {
     const strategy = HandoffStrategyFactory.createStrategy("zendesk");
     expect(strategy).toBeInstanceOf(ZendeskStrategy);
@@ -17,6 +46,30 @@ describe("HandoffStrategyFactory", () => {
 
   it("creates a SalesforceStrategy for salesforce type", () => {
     const strategy = HandoffStrategyFactory.createStrategy("salesforce");
+    expect(strategy).toBeInstanceOf(SalesforceStrategy);
+  });
+
+  it("creates a ZendeskStrategy with configuration", () => {
+    const strategy = HandoffStrategyFactory.createStrategy(
+      "zendesk",
+      zendeskConfig,
+    );
+    expect(strategy).toBeInstanceOf(ZendeskStrategy);
+  });
+
+  it("creates a FrontStrategy with configuration", () => {
+    const strategy = HandoffStrategyFactory.createStrategy(
+      "front",
+      frontConfig,
+    );
+    expect(strategy).toBeInstanceOf(FrontStrategy);
+  });
+
+  it("creates a SalesforceStrategy with configuration", () => {
+    const strategy = HandoffStrategyFactory.createStrategy(
+      "salesforce",
+      salesforceConfig,
+    );
     expect(strategy).toBeInstanceOf(SalesforceStrategy);
   });
 

--- a/__tests__/lib/handoff/SalesforceStrategy.test.ts
+++ b/__tests__/lib/handoff/SalesforceStrategy.test.ts
@@ -16,7 +16,15 @@ describe("SalesforceStrategy", () => {
   let strategy: SalesforceStrategy;
 
   beforeEach(() => {
-    strategy = new SalesforceStrategy();
+    strategy = new SalesforceStrategy({
+      type: "salesforce",
+      orgId: "test-org",
+      chatHostUrl: "test-url",
+      chatButtonId: "test-button",
+      deploymentId: "test-deployment",
+      eswLiveAgentDevName: "test-name",
+      apiSecret: "test-secret",
+    });
   });
 
   describe("formatMessages", () => {
@@ -167,6 +175,61 @@ describe("SalesforceStrategy", () => {
         },
         shouldEndHandoff: false,
       });
+    });
+
+    it("ends handoff when message contains terminating text", () => {
+      strategy = new SalesforceStrategy({
+        type: "salesforce",
+        orgId: "test-org",
+        chatHostUrl: "test-url",
+        chatButtonId: "test-button",
+        deploymentId: "test-deployment",
+        eswLiveAgentDevName: "test-name",
+        apiSecret: "test-secret",
+        handoffTerminatingMessageText: "goodbye",
+      });
+
+      const event = createSalesforceEvent(
+        SALESFORCE_MESSAGE_TYPES.ChatMessage,
+        "Agent",
+        "Thanks for chatting, goodbye!",
+      );
+
+      const result = strategy.handleChatEvent(event);
+      expect(result.shouldEndHandoff).toBe(true);
+    });
+
+    it("does not end handoff when terminating text is not present", () => {
+      strategy = new SalesforceStrategy({
+        type: "salesforce",
+        orgId: "test-org",
+        chatHostUrl: "test-url",
+        chatButtonId: "test-button",
+        deploymentId: "test-deployment",
+        eswLiveAgentDevName: "test-name",
+        apiSecret: "test-secret",
+        handoffTerminatingMessageText: "goodbye",
+      });
+
+      const event = createSalesforceEvent(
+        SALESFORCE_MESSAGE_TYPES.ChatMessage,
+        "Agent",
+        "How can I help you?",
+      );
+
+      const result = strategy.handleChatEvent(event);
+      expect(result.shouldEndHandoff).toBe(false);
+    });
+
+    it("does not end handoff when terminating text is not configured", () => {
+      const event = createSalesforceEvent(
+        SALESFORCE_MESSAGE_TYPES.ChatMessage,
+        "Agent",
+        "Thanks for chatting, goodbye!",
+      );
+
+      const result = strategy.handleChatEvent(event);
+      expect(result.shouldEndHandoff).toBe(false);
     });
   });
 

--- a/__tests__/lib/handoff/test-utils.ts
+++ b/__tests__/lib/handoff/test-utils.ts
@@ -42,11 +42,12 @@ export function createBotMessage(responses: BotResponse[]): Message {
 export function createSalesforceEvent(
   type: SalesforceMessageType,
   agentName?: string,
+  messageText: string = "Hello",
 ): SalesforceChatMessage {
   return {
     type,
     message: {
-      text: "Hello",
+      text: messageText,
       name: agentName || "Unknown Agent",
       schedule: {
         responseDelayMilliseconds: 0,

--- a/__tests__/lib/useHandoff.test.ts
+++ b/__tests__/lib/useHandoff.test.ts
@@ -6,6 +6,7 @@ import type { Message, UserChatMessage, IncomingHandoffEvent } from "@/types";
 import { HandoffStrategyFactory } from "@/lib/handoff/HandoffStrategyFactory";
 import { SALESFORCE_MESSAGE_TYPES } from "@/types/salesforce";
 import { streamResponse } from "@/lib/handoff/streamUtils";
+import { useSettings } from "@/app/providers/SettingsProvider";
 
 // Mock the required providers and hooks
 vi.mock("next/dist/client/components/navigation", () => ({
@@ -136,10 +137,31 @@ describe("useHandoff", () => {
       expect(result.current.shouldSupressHandoffInputDisplay).toBe(false);
     });
 
-    test("should create strategy on mount", () => {
+    test("should create strategy with configuration on mount", () => {
+      const handoffConfig = {
+        type: "salesforce" as const,
+        orgId: "test-org",
+        chatHostUrl: "test-url",
+        chatButtonId: "test-button",
+        deploymentId: "test-deployment",
+        eswLiveAgentDevName: "test-name",
+        apiSecret: "test-secret",
+        handoffTerminatingMessageText: "goodbye",
+        enableAvailabilityCheck: true,
+      };
+
+      vi.mocked(useSettings).mockReturnValue({
+        branding: {},
+        security: {},
+        misc: {
+          handoffConfiguration: handoffConfig,
+        },
+      });
+
       renderHook(() => useHandoff(defaultProps));
       expect(HandoffStrategyFactory.createStrategy).toHaveBeenCalledWith(
-        "zendesk",
+        "salesforce",
+        handoffConfig,
       );
     });
   });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -101,6 +101,8 @@ const parseHandoffConfiguration = (
       availabilityFallbackMessage:
         parsedHandoffConfiguration.availabilityFallbackMessage,
       allowAnonymousHandoff: parsedHandoffConfiguration.allowAnonymousHandoff,
+      handoffTerminatingMessageText:
+        parsedHandoffConfiguration.handoffTerminatingMessageText,
     };
   } catch (error) {
     console.error("Error parsing handoff configuration:", error);

--- a/lib/handoff/FrontStrategy.ts
+++ b/lib/handoff/FrontStrategy.ts
@@ -5,10 +5,13 @@ import {
 import type { Message, HandoffChatMessage } from "@/types";
 import type { Front } from "@/types/front";
 import { isChatUserMessage, isBotMessage } from "@/types";
+import type { FrontHandoffConfiguration } from "@/types/frontHandoffConfiguration";
 
 export class FrontStrategy implements HandoffStrategy {
   messagesEndpoint = "/api/front/messages";
   conversationsEndpoint = "/api/front/conversations";
+
+  constructor(private readonly configuration: FrontHandoffConfiguration) {}
 
   formatMessages(
     messages: Message[],

--- a/lib/handoff/FrontStrategy.ts
+++ b/lib/handoff/FrontStrategy.ts
@@ -5,7 +5,6 @@ import {
 import type { Message, HandoffChatMessage } from "@/types";
 import type { Front } from "@/types/front";
 import { isChatUserMessage, isBotMessage } from "@/types";
-import type { FrontHandoffConfiguration } from "@/types/frontHandoffConfiguration";
 
 export class FrontStrategy implements HandoffStrategy {
   messagesEndpoint = "/api/front/messages";

--- a/lib/handoff/HandoffStrategyFactory.ts
+++ b/lib/handoff/HandoffStrategyFactory.ts
@@ -8,14 +8,19 @@ export type HandoffType = "zendesk" | "front" | "salesforce" | null | undefined;
 export class HandoffStrategyFactory {
   static createStrategy(
     type: HandoffType,
+    configuration?: HandoffConfiguration,
   ): HandoffStrategy<Record<string, any>> | null {
     switch (type) {
       case "zendesk":
-        return new ZendeskStrategy();
+        return new ZendeskStrategy(
+          configuration as ZendeskHandoffConfiguration,
+        );
       case "front":
-        return new FrontStrategy();
+        return new FrontStrategy(configuration as FrontHandoffConfiguration);
       case "salesforce":
-        return new SalesforceStrategy();
+        return new SalesforceStrategy(
+          configuration as SalesforceHandoffConfiguration,
+        );
       case null:
       case undefined:
       default:

--- a/lib/handoff/SalesforceStrategy.ts
+++ b/lib/handoff/SalesforceStrategy.ts
@@ -28,10 +28,19 @@ export class SalesforceStrategy implements HandoffStrategy<Message> {
   readonly connectedToAgentMessageType =
     SALESFORCE_MESSAGE_TYPES.ChatConnecting;
 
+  constructor(private readonly configuration: SalesforceHandoffConfiguration) {}
+
   private shouldEndHandoff(event: SalesforceChatMessage): boolean {
-    return SALESFORCE_MESSAGE_TYPES_FOR_HANDOFF_TERMINATION.includes(
-      event.type,
-    );
+    const shouldEndByType =
+      SALESFORCE_MESSAGE_TYPES_FOR_HANDOFF_TERMINATION.includes(event.type);
+
+    // Check if message text matches terminating text
+    const handoffConfig = this.configuration as SalesforceHandoffConfiguration;
+    const terminatingText = handoffConfig?.handoffTerminatingMessageText;
+    const shouldEndByText =
+      terminatingText && event.message?.text?.includes(terminatingText);
+
+    return shouldEndByType || !!shouldEndByText;
   }
 
   /**

--- a/lib/handoff/ZendeskStrategy.ts
+++ b/lib/handoff/ZendeskStrategy.ts
@@ -14,6 +14,8 @@ export class ZendeskStrategy implements HandoffStrategy {
   messagesEndpoint = "/api/zendesk/messages";
   conversationsEndpoint = "/api/zendesk/conversations";
 
+  constructor(private readonly configuration: ZendeskHandoffConfiguration) {}
+
   formatMessages(
     messages: Message[],
     _mavenConversationId: string,

--- a/lib/useHandoff.ts
+++ b/lib/useHandoff.ts
@@ -41,7 +41,10 @@ export function useHandoff({
   const { misc } = useSettings();
   const handoffTypeRef = useRef(misc.handoffConfiguration?.type ?? null);
   const strategyRef = useRef(
-    HandoffStrategyFactory.createStrategy(handoffTypeRef.current),
+    HandoffStrategyFactory.createStrategy(
+      handoffTypeRef.current,
+      misc.handoffConfiguration as HandoffConfiguration,
+    ),
   );
   const abortController = useRef(new AbortController());
   const reconnectTimeoutRef = useRef<NodeJS.Timeout>();
@@ -58,6 +61,7 @@ export function useHandoff({
   useEffect(() => {
     strategyRef.current = HandoffStrategyFactory.createStrategy(
       handoffTypeRef.current,
+      misc.handoffConfiguration as HandoffConfiguration,
     );
   }, []);
 

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -70,6 +70,7 @@ declare global {
     surveyLink?: string;
     enableAvailabilityCheck?: boolean;
     availabilityFallbackMessage?: string;
+    handoffTerminatingMessageText?: string;
   };
 
   type HandoffConfiguration =
@@ -85,7 +86,11 @@ declare global {
 
   type ClientSafeHandoffConfig = Pick<
     HandoffConfiguration,
-    "type" | "surveyLink" | "enableAvailabilityCheck" | "allowAnonymousHandoff"
+    | "type"
+    | "surveyLink"
+    | "enableAvailabilityCheck"
+    | "allowAnonymousHandoff"
+    | "handoffTerminatingMessageText"
   > & {
     availabilityFallbackMessage?: SalesforceHandoffConfiguration["availabilityFallbackMessage"];
   };


### PR DESCRIPTION
# Description
Adds configuration option to end Salesforce handoffs based on specific message text.

## Changes
- Added `handoffTerminatingMessageText` to `SalesforceHandoffConfiguration`
- Updated `SalesforceStrategy` to check message text against terminating text
- Added configuration passing through `HandoffStrategyFactory`
- Exposed `handoffTerminatingMessageText` in client-safe configuration

## Testing
- Added tests for `SalesforceStrategy` terminating message behavior
- Added tests for configuration passing in `HandoffStrategyFactory`
- Added tests for client-safe configuration in `actions.test.ts`
- Added tests for configuration in `useHandoff`