### PR TITLE
feat: add a new property to AppSettings for new logo field

### DIFF
--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -162,7 +162,7 @@ describe("getPublicAppSettings", () => {
       appSettings: {
         get: vi.fn().mockResolvedValue({
           branding: {
-            logoUrl: "logo.png",
+            logo: "logo.png",
             brandColor: "#000",
           },
           security: {
@@ -192,7 +192,7 @@ describe("getPublicAppSettings", () => {
 
     expect(result).toEqual({
       branding: {
-        logoUrl: "logo.png",
+        logo: "logo.png",
         brandColor: "#000",
       },
       security: {

--- a/__tests__/lib/settings.test.ts
+++ b/__tests__/lib/settings.test.ts
@@ -15,7 +15,7 @@ describe("adaptLegacySettings", () => {
       embedAllowlist: ["legacy-domain"],
       enableDemoSite: "true",
       welcomeMessage: "legacy-welcome",
-      disableAttachments: true,
+      disableAttachments: "true",
       branding: {},
       security: {},
       misc: {},
@@ -25,7 +25,7 @@ describe("adaptLegacySettings", () => {
 
     expect(result).toEqual({
       branding: {
-        logoUrl: "legacy-logo.png",
+        logo: "legacy-logo.png",
         brandColor: "#legacy",
         brandFontColor: "#legacyFont",
         welcomeMessage: "legacy-welcome",
@@ -40,7 +40,7 @@ describe("adaptLegacySettings", () => {
       misc: {
         handoffConfiguration: "legacy-handoff",
         amplitudeApiKey: "legacy-key",
-        disableAttachments: true,
+        disableAttachments: "true",
       },
     });
   });
@@ -49,7 +49,7 @@ describe("adaptLegacySettings", () => {
     const settings = {
       logoUrl: "legacy-logo.png",
       branding: {
-        logoUrl: "new-logo.png",
+        logo: "new-logo.png",
         brandColor: "#new",
       },
       security: {
@@ -62,7 +62,7 @@ describe("adaptLegacySettings", () => {
 
     const result = adaptLegacySettings(settings);
 
-    expect(result.branding.logoUrl).toBe("new-logo.png");
+    expect(result.branding.logo).toBe("new-logo.png");
     expect(result.security.jwtPublicKey).toBe("new-jwt");
     expect(result.misc.amplitudeApiKey).toBe("new-key");
   });
@@ -79,7 +79,7 @@ describe("adaptLegacySettings", () => {
 
     expect(result).toEqual({
       branding: {
-        logoUrl: "logo.png",
+        logo: "logo.png",
         brandColor: undefined,
         brandFontColor: undefined,
         welcomeMessage: undefined,
@@ -110,7 +110,7 @@ describe("adaptLegacySettings", () => {
 
     expect(result).toEqual({
       branding: {
-        logoUrl: undefined,
+        logo: undefined,
         brandColor: undefined,
         brandFontColor: undefined,
         welcomeMessage: undefined,
@@ -185,5 +185,54 @@ describe("adaptLegacySettings", () => {
     const legacyResult = adaptLegacySettings(legacyOnlySettings);
 
     expect(legacyResult.security.embedAllowlist).toEqual(["legacy.com"]);
+  });
+
+  it("handles logo field migration correctly", () => {
+    const testCases = [
+      {
+        input: {
+          logoUrl: "legacy.png",
+          branding: { logo: "new.png" },
+          security: {},
+          misc: {},
+        },
+        expected: "new.png",
+        description: "prefers branding.logo over legacy logoUrl",
+      },
+      {
+        input: {
+          logoUrl: "legacy.png",
+          branding: { logoUrl: "branding-legacy.png" },
+          security: {},
+          misc: {},
+        },
+        expected: "branding-legacy.png",
+        description: "prefers branding.logoUrl over legacy logoUrl",
+      },
+      {
+        input: {
+          logoUrl: "legacy.png",
+          branding: {},
+          security: {},
+          misc: {},
+        },
+        expected: "legacy.png",
+        description: "falls back to legacy logoUrl",
+      },
+      {
+        input: {
+          branding: { logo: "new.png", logoUrl: "old.png" },
+          security: {},
+          misc: {},
+        },
+        expected: "new.png",
+        description: "prefers logo over logoUrl in branding",
+      },
+    ];
+
+    testCases.forEach(({ input, expected, description }) => {
+      const result = adaptLegacySettings(input);
+      expect(result.branding.logo, description).toBe(expected);
+    });
   });
 });

--- a/__tests__/packages/components/chat/ChatHeader.test.tsx
+++ b/__tests__/packages/components/chat/ChatHeader.test.tsx
@@ -7,7 +7,7 @@ describe("ChatHeader", () => {
     "https://app.mavenagi.com/_next/image?url=%2Fapi%2Fv1%2Ffiles%2Fage_CSMoGtyyQNJ0z8XzyMXK2Jbk%2Flogo%3F1730414949621&w=256&q=75";
   const customLogoUrl = "https://example.com/custom-logo.png";
 
-  it("renders with default logo when no logoUrl is provided", () => {
+  it("renders with default logo when no logo is provided", () => {
     render(<ChatHeader />);
 
     const logoImage = screen.getByRole("img", { name: /logo/i });
@@ -18,8 +18,8 @@ describe("ChatHeader", () => {
     );
   });
 
-  it("renders with custom logo when logoUrl is provided", () => {
-    render(<ChatHeader logoUrl={customLogoUrl} />);
+  it("renders with custom logo when logo is provided", () => {
+    render(<ChatHeader logo={customLogoUrl} />);
 
     const logoImage = screen.getByRole("img", { name: /logo/i });
     expect(logoImage).toBeInTheDocument();

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -44,7 +44,7 @@ vi.mock("@/app/providers/SettingsProvider", () => ({
   useSettings: () => ({
     branding: {
       brandColor: "#000000",
-      logoUrl: "https://www.mavenagi-static.com/logos/mavenagi.png",
+      logo: "https://www.mavenagi-static.com/logos/mavenagi.png",
     },
     security: {},
     misc: {},

--- a/app/[organizationId]/[agentId]/page.tsx
+++ b/app/[organizationId]/[agentId]/page.tsx
@@ -88,7 +88,7 @@ function ChatPage() {
 
   return (
     <main className="flex h-screen flex-col bg-gray-50">
-      <ChatHeader logoUrl={branding.logoUrl} />
+      <ChatHeader logo={branding.logo} />
       <Chat
         {...{
           agentName,

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -19,7 +19,9 @@ export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
   // Set branding properties
   adapted.branding = {
     ...(adapted.branding || {}),
-    logoUrl: settings.branding?.logoUrl ?? settings.logoUrl,
+    // TODO: Remove logoUrl once we have migrated all users to the new logo field
+    logo:
+      settings.branding?.logo ?? settings.branding?.logoUrl ?? settings.logoUrl,
     brandColor: settings.branding?.brandColor ?? settings.brandColor,
     brandFontColor:
       settings.branding?.brandFontColor ?? settings.brandFontColor,

--- a/packages/components/chat/ChatHeader.tsx
+++ b/packages/components/chat/ChatHeader.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
 
 interface ChatHeaderProps {
-  logoUrl?: string;
+  logo?: string;
 }
 
-export function ChatHeader({ logoUrl }: ChatHeaderProps) {
+export function ChatHeader({ logo }: ChatHeaderProps) {
   const defaultLogo =
     "https://app.mavenagi.com/_next/image?url=%2Fapi%2Fv1%2Ffiles%2Fage_CSMoGtyyQNJ0z8XzyMXK2Jbk%2Flogo%3F1730414949621&w=256&q=75";
 
@@ -12,7 +12,7 @@ export function ChatHeader({ logoUrl }: ChatHeaderProps) {
     <div role="banner" className="border-b border-gray-300 bg-white md:block">
       <div className="text-md flex p-5 font-medium text-gray-950">
         <Image
-          src={logoUrl || defaultLogo}
+          src={logo || defaultLogo}
           alt="Logo"
           width={98}
           height={24}

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -1,23 +1,37 @@
 declare global {
   // Legacy AppSettings interface kept for reference during migration
   interface LegacyAppSettings {
+    /** @deprecated Use AppSettings.branding.logo instead */
     logoUrl?: string;
+    /** @deprecated Use AppSettings.branding.brandColor instead */
     brandColor?: string;
+    /** @deprecated Use AppSettings.branding.brandFontColor instead */
     brandFontColor?: string;
+    /** @deprecated Use AppSettings.misc.amplitudeApiKey instead */
     amplitudeApiKey?: string;
+    /** @deprecated Use AppSettings.branding.popularQuestions instead */
     popularQuestions?: string[] | string;
+    /** @deprecated Use AppSettings.security.jwtPublicKey instead */
     jwtPublicKey?: string;
+    /** @deprecated Use AppSettings.security.encryptionSecret instead */
     encryptionSecret?: string;
+    /** @deprecated Use AppSettings.misc.handoffConfiguration instead */
     handoffConfiguration?: string;
+    /** @deprecated Use AppSettings.security.embedAllowlist instead */
     embedAllowlist?: string[];
+    /** @deprecated Use AppSettings.security.enablePreviewSite instead */
     enableDemoSite?: string;
+    /** @deprecated Use AppSettings.branding.welcomeMessage instead */
     welcomeMessage?: string;
+    /** @deprecated Use AppSettings.misc.disableAttachments instead */
     disableAttachments?: string;
   }
 
   interface AppSettings {
     branding: {
+      /** @deprecated Use logo instead */
       logoUrl?: string;
+      logo?: string;
       brandColor?: string;
       brandFontColor?: string;
       welcomeMessage?: string;


### PR DESCRIPTION
# Description
Adds new `logo` field to `AppSettings` and deprecates `logoUrl`.

## Changes
- Added `logo` field to `AppSettings.branding`
- Marked `logoUrl` as deprecated in both `LegacyAppSettings` and `AppSettings.branding`
- Updated `adaptLegacySettings` to handle logo migration
- Updated components to use new `logo` field
- Updated tests to verify logo field migration

## Testing
- Added test cases for logo field migration paths
- Updated existing tests to use new field name

## Screenshots (chat-develop)
![image](https://github.com/user-attachments/assets/bf8dd2bd-f976-41c0-a0c0-68bc57a6c9ef)
![image](https://github.com/user-attachments/assets/6c406804-d198-44e0-85df-bb2f6857a63b)
