### PR TITLE
APP-1075: extend max duration for front handoff function

### DIFF
--- a/app/api/front/conversations/route.ts
+++ b/app/api/front/conversations/route.ts
@@ -34,6 +34,7 @@ async function updateFrontUser(
   }
 }
 
+export const maxDuration = 60; // 1 minute
 export async function POST(req: NextRequest) {
   return withAppSettings(req, async (request, settings, orgId, agentId) => {
     const { messages, signedUserData } = (await request.json()) as {


### PR DESCRIPTION
Context
- Vercel has a default 15 second function duration
- Front is tight w/ their rate-limits (rate limits are shared by company)


It doesn't happen often but here is an example where vercel needed to wait just a little longer

> START RequestId: 24ce07c6-a076-48b8-a149-307673b7bf81 [POST] /api/front/conversations status=504
> FRONT:: API Request failed { attempt: 0, message: 'Failed to fetch GET(429) /channels {"_error":{"status":429,"title":"Too Many Requests","message":"Rate limit exceeded. Please retry in 27510 milliseconds."}}', response: '', status: 429, statusText: 'Too Many Requests' }

Extending the function duration to have more time when front rate-limits are hit.
