### PR TITLE
feat: change default brand font color to black

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ NOTE: The ID values for the organization and agent are the plain-text versions.
 ```typescript
 interface WidgetConfig {
   bgColor?: string; // Widget background color
-  textColor?: string; // Widget text color (default: 'white')
+  textColor?: string; // Widget text color (default: 'black')
   horizontalPosition?: "left" | "right"; // Widget position (default: 'right')
   verticalPosition?: "top" | "bottom"; // Widget position (default: 'bottom')
   signedUserData: string;

--- a/__tests__/packages/components/chat/Chat.test.tsx
+++ b/__tests__/packages/components/chat/Chat.test.tsx
@@ -200,7 +200,7 @@ describe("Chat", () => {
     mockUseSettings.mockReturnValue({
       branding: {
         brandColor: "#000000",
-        brandFontColor: "#FFFFFF",
+        brandFontColor: "#000000",
       },
       misc: {
         disableAttachments: true,

--- a/packages/components/chat/Chat.tsx
+++ b/packages/components/chat/Chat.tsx
@@ -103,7 +103,7 @@ export default function Chat({
         style={{
           // @ts-expect-error css variable
           "--brand-color": branding.brandColor,
-          "--brand-font-color": branding.brandFontColor || "#FFFFFF",
+          "--brand-font-color": branding.brandFontColor || "#000000",
         }}
       >
         {children}


### PR DESCRIPTION
Default brand font color has been changed to black in the `Chat` component. Documentation has been updated to reflect this change.  

![Screenshot 2025-02-27 at 12 31 23 PM](https://github.com/user-attachments/assets/715f87ac-18fa-4f39-b8fb-19daaab6c600)
