### PR TITLE
feat: add fallback image to chat header

### DIFF
--- a/__tests__/lib/settings.test.ts
+++ b/__tests__/lib/settings.test.ts
@@ -26,6 +26,7 @@ describe("adaptLegacySettings", () => {
     expect(result).toEqual({
       branding: {
         logo: "legacy-logo.png",
+        fallbackLogoUrl: "legacy-logo.png",
         brandColor: "#legacy",
         brandFontColor: "#legacyFont",
         welcomeMessage: "legacy-welcome",
@@ -50,6 +51,7 @@ describe("adaptLegacySettings", () => {
       logoUrl: "legacy-logo.png",
       branding: {
         logo: "new-logo.png",
+        logoUrl: "branding-legacy-logo.png",
         brandColor: "#new",
       },
       security: {
@@ -63,6 +65,7 @@ describe("adaptLegacySettings", () => {
     const result = adaptLegacySettings(settings);
 
     expect(result.branding.logo).toBe("new-logo.png");
+    expect(result.branding.fallbackLogoUrl).toBe("branding-legacy-logo.png");
     expect(result.security.jwtPublicKey).toBe("new-jwt");
     expect(result.misc.amplitudeApiKey).toBe("new-key");
   });
@@ -80,6 +83,7 @@ describe("adaptLegacySettings", () => {
     expect(result).toEqual({
       branding: {
         logo: "logo.png",
+        fallbackLogoUrl: "logo.png",
         brandColor: undefined,
         brandFontColor: undefined,
         welcomeMessage: undefined,
@@ -111,6 +115,7 @@ describe("adaptLegacySettings", () => {
     expect(result).toEqual({
       branding: {
         logo: undefined,
+        fallbackLogoUrl: undefined,
         brandColor: undefined,
         brandFontColor: undefined,
         welcomeMessage: undefined,
@@ -197,6 +202,7 @@ describe("adaptLegacySettings", () => {
           misc: {},
         },
         expected: "new.png",
+        expectedFallback: "legacy.png",
         description: "prefers branding.logo over legacy logoUrl",
       },
       {
@@ -207,6 +213,7 @@ describe("adaptLegacySettings", () => {
           misc: {},
         },
         expected: "branding-legacy.png",
+        expectedFallback: "branding-legacy.png",
         description: "prefers branding.logoUrl over legacy logoUrl",
       },
       {
@@ -217,6 +224,7 @@ describe("adaptLegacySettings", () => {
           misc: {},
         },
         expected: "legacy.png",
+        expectedFallback: "legacy.png",
         description: "falls back to legacy logoUrl",
       },
       {
@@ -226,13 +234,53 @@ describe("adaptLegacySettings", () => {
           misc: {},
         },
         expected: "new.png",
+        expectedFallback: "old.png",
         description: "prefers logo over logoUrl in branding",
+      },
+    ];
+
+    testCases.forEach(({ input, expected, expectedFallback, description }) => {
+      const result = adaptLegacySettings(input);
+      expect(result.branding.logo, description).toBe(expected);
+      expect(result.branding.fallbackLogoUrl, `fallback: ${description}`).toBe(
+        expectedFallback,
+      );
+    });
+  });
+
+  it("sets fallbackLogoUrl correctly", () => {
+    const testCases = [
+      {
+        input: {
+          logoUrl: "legacy.png",
+          branding: {
+            logo: "primary.png",
+            logoUrl: "secondary.png",
+          },
+          security: {},
+          misc: {},
+        },
+        expected: "secondary.png",
+        description:
+          "uses branding.logoUrl as fallback when no explicit fallback",
+      },
+      {
+        input: {
+          logoUrl: "legacy.png",
+          branding: {
+            logo: "primary.png",
+          },
+          security: {},
+          misc: {},
+        },
+        expected: "legacy.png",
+        description: "uses legacy logoUrl when no other fallback options",
       },
     ];
 
     testCases.forEach(({ input, expected, description }) => {
       const result = adaptLegacySettings(input);
-      expect(result.branding.logo, description).toBe(expected);
+      expect(result.branding.fallbackLogoUrl, description).toBe(expected);
     });
   });
 });

--- a/__tests__/packages/components/chat/ChatHeader.test.tsx
+++ b/__tests__/packages/components/chat/ChatHeader.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ChatHeader } from "@/packages/components/chat/ChatHeader";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 describe("ChatHeader", () => {
   const defaultLogo =
     "https://app.mavenagi.com/_next/image?url=%2Fapi%2Fv1%2Ffiles%2Fage_CSMoGtyyQNJ0z8XzyMXK2Jbk%2Flogo%3F1730414949621&w=256&q=75";
   const customLogoUrl = "https://example.com/custom-logo.png";
+  const fallbackLogoUrl = "https://example.com/fallback-logo.png";
 
   it("renders with default logo when no logo is provided", () => {
     render(<ChatHeader />);
@@ -23,6 +24,50 @@ describe("ChatHeader", () => {
 
     const logoImage = screen.getByRole("img", { name: /logo/i });
     expect(logoImage).toBeInTheDocument();
+    expect(logoImage).toHaveAttribute(
+      "src",
+      expect.stringContaining(customLogoUrl),
+    );
+  });
+
+  it("renders with fallback logo when provided and primary logo fails", () => {
+    render(<ChatHeader logo={customLogoUrl} fallbackLogo={fallbackLogoUrl} />);
+
+    const logoImage = screen.getByRole("img", { name: /logo/i });
+    expect(logoImage).toBeInTheDocument();
+
+    // Simulate an error on the primary logo
+    fireEvent.error(logoImage);
+
+    // After error, it should use the fallback logo
+    expect(logoImage).toHaveAttribute(
+      "src",
+      expect.stringContaining(fallbackLogoUrl),
+    );
+  });
+
+  it("falls back to default logo when both logo and fallbackLogo fail", () => {
+    render(<ChatHeader logo={customLogoUrl} fallbackLogo={fallbackLogoUrl} />);
+
+    const logoImage = screen.getByRole("img", { name: /logo/i });
+
+    // Simulate an error on the primary logo
+    fireEvent.error(logoImage);
+
+    // Simulate an error on the fallback logo
+    fireEvent.error(logoImage);
+
+    // After both errors, it should use the default logo
+    expect(logoImage).toHaveAttribute(
+      "src",
+      expect.stringContaining(defaultLogo),
+    );
+  });
+
+  it("prioritizes logo over fallbackLogo when both are provided", () => {
+    render(<ChatHeader logo={customLogoUrl} fallbackLogo={fallbackLogoUrl} />);
+
+    const logoImage = screen.getByRole("img", { name: /logo/i });
     expect(logoImage).toHaveAttribute(
       "src",
       expect.stringContaining(customLogoUrl),

--- a/__tests__/packages/components/chat/ChatHeader.test.tsx
+++ b/__tests__/packages/components/chat/ChatHeader.test.tsx
@@ -1,10 +1,9 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ChatHeader } from "@/packages/components/chat/ChatHeader";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 
 describe("ChatHeader", () => {
-  const defaultLogo =
-    "https://app.mavenagi.com/_next/image?url=%2Fapi%2Fv1%2Ffiles%2Fage_CSMoGtyyQNJ0z8XzyMXK2Jbk%2Flogo%3F1730414949621&w=256&q=75";
+  const defaultLogo = "/assets/logo/mavenagi_logo_wide_on_light_purple.svg";
   const customLogoUrl = "https://example.com/custom-logo.png";
   const fallbackLogoUrl = "https://example.com/fallback-logo.png";
 

--- a/app/[organizationId]/[agentId]/page.tsx
+++ b/app/[organizationId]/[agentId]/page.tsx
@@ -88,7 +88,10 @@ function ChatPage() {
 
   return (
     <main className="flex h-screen flex-col bg-gray-50">
-      <ChatHeader logo={branding.logo} />
+      <ChatHeader
+        logo={branding.logo}
+        fallbackLogo={branding.fallbackLogoUrl}
+      />
       <Chat
         {...{
           agentName,

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -22,6 +22,7 @@ export function adaptLegacySettings(settings: InterimAppSettings): AppSettings {
     // TODO: Remove logoUrl once we have migrated all users to the new logo field
     logo:
       settings.branding?.logo ?? settings.branding?.logoUrl ?? settings.logoUrl,
+    fallbackLogoUrl: settings.branding?.logoUrl ?? settings.logoUrl,
     brandColor: settings.branding?.brandColor ?? settings.brandColor,
     brandFontColor:
       settings.branding?.brandFontColor ?? settings.brandFontColor,

--- a/packages/components/chat/ChatHeader.tsx
+++ b/packages/components/chat/ChatHeader.tsx
@@ -1,18 +1,17 @@
 import Image from "next/image";
 import { useState, useMemo } from "react";
 
+import imgMavenPurple from "@/assets/logo/mavenagi_logo_wide_on_light_purple.svg";
+
 interface ChatHeaderProps {
   logo?: string;
   fallbackLogo?: string;
 }
 
 export function ChatHeader({ logo, fallbackLogo }: ChatHeaderProps) {
-  const defaultLogo =
-    "https://app.mavenagi.com/_next/image?url=%2Fapi%2Fv1%2Ffiles%2Fage_CSMoGtyyQNJ0z8XzyMXK2Jbk%2Flogo%3F1730414949621&w=256&q=75";
-
   // Memoize the filtered logo sources array to prevent unnecessary recalculations
   const initialSources = useMemo(() => {
-    return [logo, fallbackLogo, defaultLogo].filter(
+    return [logo, fallbackLogo, imgMavenPurple].filter(
       (src): src is string => Boolean(src) && src !== "",
     );
   }, [logo, fallbackLogo]);

--- a/packages/components/chat/ChatHeader.tsx
+++ b/packages/components/chat/ChatHeader.tsx
@@ -1,23 +1,56 @@
 import Image from "next/image";
+import { useState, useMemo } from "react";
 
 interface ChatHeaderProps {
   logo?: string;
+  fallbackLogo?: string;
 }
 
-export function ChatHeader({ logo }: ChatHeaderProps) {
+export function ChatHeader({ logo, fallbackLogo }: ChatHeaderProps) {
   const defaultLogo =
     "https://app.mavenagi.com/_next/image?url=%2Fapi%2Fv1%2Ffiles%2Fage_CSMoGtyyQNJ0z8XzyMXK2Jbk%2Flogo%3F1730414949621&w=256&q=75";
+
+  // Memoize the filtered logo sources array to prevent unnecessary recalculations
+  const initialSources = useMemo(() => {
+    return [logo, fallbackLogo, defaultLogo].filter(
+      (src): src is string => Boolean(src) && src !== "",
+    );
+  }, [logo, fallbackLogo]);
+
+  // Initialize state with memoized values for optimal performance
+  const [logoSources, setLogoSources] = useState<string[]>(initialSources);
+  const [currentSrc, setCurrentSrc] = useState<string>(initialSources[0] || "");
+
+  /**
+   * Handles image loading errors by removing the current source
+   * and attempting to load the next available source in the fallback chain.
+   */
+  const handleError = () => {
+    // Clone and update the sources array to maintain immutability
+    const updatedSources = [...logoSources];
+    updatedSources.shift();
+
+    setLogoSources(updatedSources);
+
+    // Attempt to load the next source if available
+    if (updatedSources.length > 0) {
+      setCurrentSrc(updatedSources[0]);
+    }
+  };
 
   return (
     <div role="banner" className="border-b border-gray-300 bg-white md:block">
       <div className="text-md flex p-5 font-medium text-gray-950">
-        <Image
-          src={logo || defaultLogo}
-          alt="Logo"
-          width={98}
-          height={24}
-          className="h-8 w-auto"
-        />
+        {currentSrc && (
+          <Image
+            src={currentSrc}
+            alt="Logo"
+            width={98}
+            height={24}
+            className="h-8 w-auto"
+            onError={handleError}
+          />
+        )}
       </div>
     </div>
   );

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -31,6 +31,8 @@ declare global {
     branding: {
       /** @deprecated Use logo instead */
       logoUrl?: string;
+      /** @deprecated Use logo instead */
+      fallbackLogoUrl?: string;
       logo?: string;
       brandColor?: string;
       brandFontColor?: string;


### PR DESCRIPTION
# Add fallback mechanism for chat header logo

This PR implements a fallback mechanism for the chat header logo to handle cases where image URLs might be invalid or inaccessible.

## Changes

- Enhanced `ChatHeader` component with a three-layer fallback system:
  1. Primary logo (`logo` prop)
  2. Fallback logo (`fallbackLogo` prop from legacy fields)
  3. Default logo (hardcoded)
- Added error handling to detect and recover from image loading failures
- Updated settings adapter to provide fallback logo URL from legacy settings
- Added type definition for `fallbackLogoUrl` in settings interface
- Updated page component to pass fallback logo to header
- Added test coverage for the fallback mechanism

## Implementation Details

- Used array-based approach for managing fallback sources
- Implemented memoization to prevent unnecessary recalculations
- Added proper error handling for image loading failures
- Maintained immutability when updating state

This change addresses issues where blob storage URLs might be invalid or inaccessible, ensuring users always see a logo in the chat header.