### PR TITLE
feat: update default colors

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ NOTE: The ID values for the organization and agent are the plain-text versions.
 ```typescript
 interface WidgetConfig {
   bgColor?: string; // Widget background color
-  textColor?: string; // Widget text color (default: 'black')
+  textColor?: string; // Widget text color (default: 'white')
   horizontalPosition?: "left" | "right"; // Widget position (default: 'right')
   verticalPosition?: "top" | "bottom"; // Widget position (default: 'bottom')
   signedUserData: string;


### PR DESCRIPTION
[APP-1088](https://linear.app/mavenagi/issue/APP-1088/defaults-results-in-bad-setup-for-chat-v2)

We now have set the `brandFontColor` to white for any agent installs that had just the `brandColor` set.  