### PR TITLE
feat: zendesk live handoff include custom fields message

### DIFF
--- a/settings.d.ts
+++ b/settings.d.ts
@@ -73,6 +73,7 @@ declare global {
     availabilityCheckApiEmail?: string;
     availabilityCheckApiToken?: string;
     customFields?: CustomField[];
+    shouldIncludeCustomFieldsInHandoffMessage?: boolean;
   };
   type FrontHandoffConfiguration = BaseHandoffConfiguration & {
     type: "front";

--- a/src/app/api/zendesk/conversations/route.ts
+++ b/src/app/api/zendesk/conversations/route.ts
@@ -150,7 +150,7 @@ const createCustomFieldsMesage = (
       type: "text",
       text: `Custom fields:
 ${Object.entries(customFieldValues)
-  .map(([key, value]) => `${key}: ${value}`)
+  .map(([key, value]) => `${key}: ${String(value)}`)
   .join("\n")}
     `,
     },

--- a/src/app/api/zendesk/conversations/route.ts
+++ b/src/app/api/zendesk/conversations/route.ts
@@ -129,6 +129,42 @@ const getOrCreateZendeskConversation = async (
   return conversation;
 };
 
+/**
+ * Creates a message containing custom field values for Zendesk handoff.
+ * This is a temporary workaround to display custom fields in the conversation.
+ *
+ * @param userId - The ID of the user who owns the conversation
+ * @param customFieldValues - A record of custom field keys and their values
+ * @returns A message object formatted for Zendesk's API with custom field values
+ */
+const createCustomFieldsMesage = (
+  userId: string,
+  customFieldValues: Record<string, string | boolean | number | undefined>,
+) => {
+  return {
+    author: {
+      type: "business",
+      userId,
+    },
+    content: {
+      type: "text",
+      text: `Custom fields:
+${Object.entries(customFieldValues)
+  .map(([key, value]) => `${key}: ${value}`)
+  .join("\n")}
+    `,
+    },
+  };
+};
+
+/**
+ * Creates a message notifying Zendesk agents that the user is unauthenticated.
+ * This message is sent when a user without signed user data or email attempts to hand off.
+ *
+ * @param userId - The ID of the user who owns the conversation
+ * @param email - The email address the user is claiming to own
+ * @returns A message object formatted for Zendesk's API with authentication warning
+ */
 const createUnauthenticatedMessage = (userId: string, email: string) => ({
   author: {
     type: "business",
@@ -212,6 +248,11 @@ export async function POST(req: NextRequest) {
     const isAuthenticated = !!verifiedUserInfo;
     if (!isAuthenticated) {
       messages.push(createUnauthenticatedMessage(userId, email));
+    }
+
+    // TODO: This is a temporary workaround that should be removed immediately when the root issue is resolved
+    if (handoffConfiguration.shouldIncludeCustomFieldsInHandoffMessage) {
+      messages.push(createCustomFieldsMesage(userId, customFieldValues));
     }
 
     await postMessagesToZendeskConversation(

--- a/src/app/api/zendesk/conversations/route.ts
+++ b/src/app/api/zendesk/conversations/route.ts
@@ -137,7 +137,7 @@ const getOrCreateZendeskConversation = async (
  * @param customFieldValues - A record of custom field keys and their values
  * @returns A message object formatted for Zendesk's API with custom field values
  */
-const createCustomFieldsMesage = (
+const createCustomFieldsMessage = (
   userId: string,
   customFieldValues: Record<string, string | boolean | number | undefined>,
 ) => {
@@ -252,7 +252,7 @@ export async function POST(req: NextRequest) {
 
     // TODO: This is a temporary workaround that should be removed immediately when the root issue is resolved
     if (handoffConfiguration.shouldIncludeCustomFieldsInHandoffMessage) {
-      messages.push(createCustomFieldsMesage(userId, customFieldValues));
+      messages.push(createCustomFieldsMessage(userId, customFieldValues));
     }
 
     await postMessagesToZendeskConversation(


### PR DESCRIPTION
Adds a temporary workaround to display custom fields in Zendesk handoff conversations. This will be removed once the root issue is resolved.

Changes:
- Add shouldIncludeCustomFieldsInHandoffMessage config option
- Add createCustomFieldsMesage helper function

The custom fields message will be displayed in the ZD conversation when shouldIncludeCustomFieldsInHandoffMessage is enabled, allowing agents to see custom field values during handoff.
