### PR TITLE
feat: add salesforce-messaging strategy

### DIFF
--- a/__tests__/lib/handoff/HandoffStrategyFactory.test.ts
+++ b/__tests__/lib/handoff/HandoffStrategyFactory.test.ts
@@ -3,6 +3,7 @@ import { HandoffStrategyFactory } from "@/src/lib/handoff/HandoffStrategyFactory
 import { ZendeskStrategy } from "@/src/lib/handoff/ZendeskStrategy";
 import { FrontStrategy } from "@/src/lib/handoff/FrontStrategy";
 import { SalesforceStrategy } from "@/src/lib/handoff/SalesforceStrategy";
+import { SalesforceMessagingStrategy } from "@/src/lib/handoff/SalesforceMessagingStrategy";
 
 describe("HandoffStrategyFactory", () => {
   const salesforceConfig = {
@@ -14,25 +15,19 @@ describe("HandoffStrategyFactory", () => {
     eswLiveAgentDevName: "test-name",
     apiSecret: "test-secret",
     handoffTerminatingMessageText: "goodbye",
-  };
+  } as ClientSafeHandoffConfig;
 
   const zendeskConfig = {
     type: "zendesk" as const,
-    apiKey: "test-api-key",
-    apiSecret: "test-api-secret",
-    appId: "test-app-id",
-    webhookId: "test-webhook-id",
-    webhookSecret: "test-webhook-secret",
-    subdomain: "test-subdomain",
-  };
+  } as ClientSafeHandoffConfig;
 
   const frontConfig = {
     type: "front" as const,
-    apiKey: "test-api-key",
-    apiSecret: "test-api-secret",
-    appId: "test-app-id",
-    channelName: "test-channel",
-  };
+  } as ClientSafeHandoffConfig;
+
+  const salesforceMessagingConfig = {
+    type: "salesforce-messaging" as const,
+  } as ClientSafeHandoffConfig;
 
   it("creates a ZendeskStrategy for zendesk type", () => {
     const strategy = HandoffStrategyFactory.createStrategy("zendesk");
@@ -47,6 +42,13 @@ describe("HandoffStrategyFactory", () => {
   it("creates a SalesforceStrategy for salesforce type", () => {
     const strategy = HandoffStrategyFactory.createStrategy("salesforce");
     expect(strategy).toBeInstanceOf(SalesforceStrategy);
+  });
+
+  it("creates a SalesforceMessagingStrategy for salesforce-messaging type", () => {
+    const strategy = HandoffStrategyFactory.createStrategy(
+      "salesforce-messaging",
+    );
+    expect(strategy).toBeInstanceOf(SalesforceMessagingStrategy);
   });
 
   it("creates a ZendeskStrategy with configuration", () => {
@@ -71,6 +73,14 @@ describe("HandoffStrategyFactory", () => {
       salesforceConfig,
     );
     expect(strategy).toBeInstanceOf(SalesforceStrategy);
+  });
+
+  it("creates a SalesforceMessagingStrategy with configuration", () => {
+    const strategy = HandoffStrategyFactory.createStrategy(
+      "salesforce-messaging",
+      salesforceMessagingConfig,
+    );
+    expect(strategy).toBeInstanceOf(SalesforceMessagingStrategy);
   });
 
   it("returns null for null type", () => {

--- a/__tests__/lib/handoff/SalesforceMessagingStrategy.test.ts
+++ b/__tests__/lib/handoff/SalesforceMessagingStrategy.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SalesforceMessagingStrategy } from "@/src/lib/handoff/SalesforceMessagingStrategy";
+
+describe("SalesforceMessagingStrategy", () => {
+  let strategy: SalesforceMessagingStrategy;
+
+  beforeEach(() => {
+    strategy = new SalesforceMessagingStrategy({
+      type: "salesforce-messaging",
+    });
+  });
+
+  describe("properties", () => {
+    it("should have required endpoints", () => {
+      expect(strategy.messagesEndpoint).toBe("/api/salesforce/messages");
+      expect(strategy.conversationsEndpoint).toBe(
+        "/api/salesforce/conversations",
+      );
+    });
+  });
+
+  describe("methods", () => {
+    it("should have formatMessages method", () => {
+      expect(typeof strategy.formatMessages).toBe("function");
+    });
+
+    it("should have handleChatEvent method", () => {
+      expect(typeof strategy.handleChatEvent).toBe("function");
+    });
+  });
+});

--- a/__tests__/lib/handoff/SalesforceMessagingStrategy.test.ts
+++ b/__tests__/lib/handoff/SalesforceMessagingStrategy.test.ts
@@ -12,9 +12,11 @@ describe("SalesforceMessagingStrategy", () => {
 
   describe("properties", () => {
     it("should have required endpoints", () => {
-      expect(strategy.messagesEndpoint).toBe("/api/salesforce/messages");
+      expect(strategy.messagesEndpoint).toBe(
+        "/api/salesforce-messaging/messages",
+      );
       expect(strategy.conversationsEndpoint).toBe(
-        "/api/salesforce/conversations",
+        "/api/salesforce-messaging/conversations",
       );
     });
   });

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -80,25 +80,29 @@ declare global {
     host?: string;
     shiftNames?: string[];
   };
-  type SalesforceHandoffConfiguration = {
+  type SalesforceHandoffConfiguration = BaseHandoffConfiguration & {
     type: "salesforce";
     orgId: string;
     chatHostUrl: string;
     chatButtonId: string;
     deploymentId: string;
     eswLiveAgentDevName: string;
-    allowAnonymousHandoff?: boolean;
-    apiSecret: string;
-    surveyLink?: string;
     enableAvailabilityCheck?: boolean;
     availabilityFallbackMessage?: string;
     handoffTerminatingMessageText?: string;
+  };
+  type SalesforceMessagingHandoffConfiguration = BaseHandoffConfiguration & {
+    type: "salesforce-messaging";
+    organizationId: string;
+    deploymentId: string;
+    messagingUrl: string;
   };
 
   type HandoffConfiguration =
     | ZendeskHandoffConfiguration
     | FrontHandoffConfiguration
-    | SalesforceHandoffConfiguration;
+    | SalesforceHandoffConfiguration
+    | SalesforceMessagingHandoffConfiguration;
 
   interface ParsedAppSettings extends Omit<AppSettings, "misc"> {
     misc: AppSettings["misc"] & {
@@ -106,17 +110,19 @@ declare global {
     };
   }
 
-  type ClientSafeHandoffConfig = Pick<
-    HandoffConfiguration,
-    | "type"
-    | "surveyLink"
-    | "enableAvailabilityCheck"
-    | "allowAnonymousHandoff"
-    | "handoffTerminatingMessageText"
-  > &
-    Pick<ZendeskHandoffConfiguration, "customFields"> & {
-      availabilityFallbackMessage?: SalesforceHandoffConfiguration["availabilityFallbackMessage"];
-    };
+  type ClientSafeHandoffConfig = {
+    type:
+      | ZendeskHandoffConfiguration["type"]
+      | SalesforceHandoffConfiguration["type"]
+      | FrontHandoffConfiguration["type"]
+      | SalesforceMessagingHandoffConfiguration["type"];
+    surveyLink?: HandoffConfiguration["surveyLink"];
+    enableAvailabilityCheck?: HandoffConfiguration["enableAvailabilityCheck"];
+    allowAnonymousHandoff?: HandoffConfiguration["allowAnonymousHandoff"];
+    handoffTerminatingMessageText?: HandoffConfiguration["handoffTerminatingMessageText"];
+    customFields?: ZendeskHandoffConfiguration["customFields"];
+    availabilityFallbackMessage?: HandoffConfiguration["availabilityFallbackMessage"];
+  };
 
   interface ClientSafeAppSettings {
     branding: AppSettings["branding"];

--- a/src/lib/handoff/HandoffStrategyFactory.ts
+++ b/src/lib/handoff/HandoffStrategyFactory.ts
@@ -2,8 +2,14 @@ import type { HandoffStrategy } from "./HandoffStrategy";
 import { ZendeskStrategy } from "./ZendeskStrategy";
 import { FrontStrategy } from "./FrontStrategy";
 import { SalesforceStrategy } from "./SalesforceStrategy";
-
-export type HandoffType = "zendesk" | "front" | "salesforce" | null | undefined;
+import { SalesforceMessagingStrategy } from "./SalesforceMessagingStrategy";
+export type HandoffType =
+  | "zendesk"
+  | "front"
+  | "salesforce"
+  | "salesforce-messaging"
+  | null
+  | undefined;
 
 export class HandoffStrategyFactory {
   static createStrategy(
@@ -17,6 +23,10 @@ export class HandoffStrategyFactory {
         return new FrontStrategy(configuration as ClientSafeHandoffConfig);
       case "salesforce":
         return new SalesforceStrategy(configuration as ClientSafeHandoffConfig);
+      case "salesforce-messaging":
+        return new SalesforceMessagingStrategy(
+          configuration as ClientSafeHandoffConfig,
+        );
       case null:
       case undefined:
       default:

--- a/src/lib/handoff/SalesforceMessagingStrategy.ts
+++ b/src/lib/handoff/SalesforceMessagingStrategy.ts
@@ -22,8 +22,10 @@ export class SalesforceMessagingStrategy implements HandoffStrategy<any> {
   }
 }
 
-export class SalesforceServerStrategy implements ServerHandoffStrategy {
-  constructor(private configuration: SalesforceHandoffConfiguration) {}
+export class SalesforceMessagingServerStrategy
+  implements ServerHandoffStrategy
+{
+  constructor(private configuration: SalesforceMessagingHandoffConfiguration) {}
 
   isLiveHandoffAvailable? = async () => {
     return true;

--- a/src/lib/handoff/SalesforceMessagingStrategy.ts
+++ b/src/lib/handoff/SalesforceMessagingStrategy.ts
@@ -1,0 +1,35 @@
+import {
+  type HandoffStrategy,
+  type ServerHandoffStrategy,
+} from "./HandoffStrategy";
+
+export class SalesforceMessagingStrategy implements HandoffStrategy<any> {
+  readonly messagesEndpoint = "/api/salesforce-messaging/messages";
+  readonly conversationsEndpoint = "/api/salesforce-messaging/conversations";
+
+  constructor(private readonly configuration: ClientSafeHandoffConfig) {}
+
+  formatMessages(messages: any[]) {
+    return messages;
+  }
+
+  handleChatEvent(event: any) {
+    return {
+      agentName: null,
+      formattedEvent: event,
+      shouldEndHandoff: false,
+    };
+  }
+}
+
+export class SalesforceServerStrategy implements ServerHandoffStrategy {
+  constructor(private configuration: SalesforceHandoffConfiguration) {}
+
+  isLiveHandoffAvailable? = async () => {
+    return true;
+  };
+
+  fetchHandoffAvailability = async () => {
+    return true;
+  };
+}

--- a/src/lib/handoff/ServerHandoffStrategyFactory.ts
+++ b/src/lib/handoff/ServerHandoffStrategyFactory.ts
@@ -2,6 +2,7 @@ import { FrontServerStrategy } from "./FrontServerStrategy";
 import type { ServerHandoffStrategy } from "./HandoffStrategy";
 import type { HandoffType } from "./HandoffStrategyFactory";
 import { SalesforceServerStrategy } from "./SalesforceStrategy";
+import { SalesforceMessagingServerStrategy } from "./SalesforceMessagingStrategy";
 import { ZendeskServerStrategy } from "./ZendeskStrategy";
 
 export class ServerHandoffStrategyFactory {
@@ -21,6 +22,10 @@ export class ServerHandoffStrategyFactory {
       case "salesforce":
         return new SalesforceServerStrategy(
           configuration as SalesforceHandoffConfiguration,
+        );
+      case "salesforce-messaging":
+        return new SalesforceMessagingServerStrategy(
+          configuration as SalesforceMessagingHandoffConfiguration,
         );
       case null:
       case undefined:


### PR DESCRIPTION
# Add Salesforce Messaging Strategy

Adds support for Salesforce Messaging as a handoff strategy.

## Changes
- Add `SalesforceMessagingStrategy` class implementing `HandoffStrategy` interface
- Add `SalesforceServerStrategy` class implementing `ServerHandoffStrategy` interface
- Update `HandoffStrategyFactory` to support "salesforce-messaging" type
- Add tests for new strategy and factory updates
- Update type definitions for Salesforce Messaging configuration